### PR TITLE
feat(go/adbc/driver/bigquery): Make OAuth access token endpoint configurable

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -28,11 +28,13 @@ import (
 type databaseImpl struct {
 	driverbase.DatabaseImplBase
 
-	authType     string
-	credentials  string
-	clientID     string
-	clientSecret string
-	refreshToken string
+	authType              string
+	credentials           string
+	clientID              string
+	clientSecret          string
+	refreshToken          string
+	accessTokenEndpoint   string
+	accessTokenServerName string
 	// projectID is the catalog
 	projectID string
 	// datasetID is the schema
@@ -48,6 +50,8 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		clientID:               d.clientID,
 		clientSecret:           d.clientSecret,
 		refreshToken:           d.refreshToken,
+		accessTokenEndpoint:    d.accessTokenEndpoint,
+		accessTokenServerName:  d.accessTokenServerName,
 		tableID:                d.tableID,
 		catalog:                d.projectID,
 		dbSchema:               d.datasetID,
@@ -129,6 +133,10 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.clientSecret = value
 	case OptionStringAuthRefreshToken:
 		d.refreshToken = value
+	case OptionStringAuthAccessTokenEndpoint:
+		d.accessTokenEndpoint = value
+	case OptionStringAuthAccessTokenServerName:
+		d.accessTokenServerName = value
 	case OptionStringProjectID:
 		d.projectID = value
 	case OptionStringDatasetID:

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -529,7 +529,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 					Msg:  fmt.Sprintf("The `%s` parameter is empty", OptionStringAuthRefreshToken),
 				}
 			}
-			if c.accessTokenEndpoint == "" {
+			if c.accessTokenEndpoint == "" || c.accessTokenEndpoint == DefaultAccessTokenEndpoint {
 				c.accessTokenEndpoint = DefaultAccessTokenEndpoint
 				// Only use default server name if the access token endpoint is also set to default
 				if c.accessTokenServerName == "" {

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -44,11 +44,13 @@ import (
 type connectionImpl struct {
 	driverbase.ConnectionImplBase
 
-	authType     string
-	credentials  string
-	clientID     string
-	clientSecret string
-	refreshToken string
+	authType              string
+	credentials           string
+	clientID              string
+	clientSecret          string
+	refreshToken          string
+	accessTokenEndpoint   string
+	accessTokenServerName string
 
 	// catalog is the same as the project id in BigQuery
 	catalog string
@@ -527,6 +529,14 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 					Msg:  fmt.Sprintf("The `%s` parameter is empty", OptionStringAuthRefreshToken),
 				}
 			}
+			if c.accessTokenEndpoint == "" {
+				c.accessTokenEndpoint = DefaultAccessTokenEndpoint
+				// Only use default server name if the access token endpoint is also set to default
+				if c.accessTokenServerName == "" {
+					c.accessTokenServerName = DefaultAccessTokenServerName
+				}
+			}
+
 			credentials = option.WithTokenSource(c)
 		}
 
@@ -812,7 +822,7 @@ func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	params.Add("client_id", c.clientID)
 	params.Add("client_secret", c.clientSecret)
 	params.Add("refresh_token", c.refreshToken)
-	req, err := http.NewRequest("POST", AccessTokenEndpoint, bytes.NewBufferString(params.Encode()))
+	req, err := http.NewRequest("POST", c.accessTokenEndpoint, bytes.NewBufferString(params.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +830,7 @@ func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	req.Header.Set("Accept", "application/json")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{ServerName: AccessTokenServerName},
+		TLSClientConfig: &tls.Config{ServerName: c.accessTokenServerName},
 	}
 	client := &http.Client{
 		Transport: tr,

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -1,0 +1,81 @@
+package bigquery
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCustomAccessTokenEndpointAndServerName(t *testing.T) {
+	accessTokenEndpoint := "https://example.com/oauth2/token"
+	accessTokenServerName := "example.com"
+	conn := &connectionImpl{
+		authType:              "adbc.bigquery.sql.auth_type.user_authentication",
+		catalog:               "test-project-id",
+		dbSchema:              "test-dataset-id",
+		tableID:               "test-table-id",
+		clientID:              "test-client-id",
+		clientSecret:          "test-client-secret",
+		refreshToken:          "test-refresh-token",
+		accessTokenEndpoint:   accessTokenEndpoint,
+		accessTokenServerName: accessTokenServerName,
+	}
+
+	err := conn.newClient(context.Background())
+	if err != nil {
+		t.Errorf("Error occurred %v", err)
+	}
+	if conn.accessTokenEndpoint != accessTokenEndpoint {
+		t.Errorf("Expected access token endpoint to be %s, but got %s", accessTokenEndpoint, conn.accessTokenEndpoint)
+	}
+	if conn.accessTokenServerName != accessTokenServerName {
+		t.Errorf("Expected access token server name to be %s, but got %s", accessTokenServerName, conn.accessTokenServerName)
+	}
+}
+
+func TestDefaultAccessTokenEndpoint(t *testing.T) {
+	conn := &connectionImpl{
+		authType:     "adbc.bigquery.sql.auth_type.user_authentication",
+		catalog:      "test-project-id",
+		dbSchema:     "test-dataset-id",
+		tableID:      "test-table-id",
+		clientID:     "test-client-id",
+		clientSecret: "test-client-secret",
+		refreshToken: "test-refresh-token",
+	}
+
+	err := conn.newClient(context.Background())
+	if err != nil {
+		t.Errorf("Error occurred %v", err)
+	}
+	if conn.accessTokenEndpoint != DefaultAccessTokenEndpoint {
+		t.Errorf("Expected access token endpoint to be %s, but got %s", DefaultAccessTokenEndpoint, conn.accessTokenEndpoint)
+	}
+	if conn.accessTokenServerName != DefaultAccessTokenServerName {
+		t.Errorf("Expected access token server name to be %s, but got %s", DefaultAccessTokenServerName, conn.accessTokenServerName)
+	}
+}
+
+func TestCustomAccessTokenEndpoint(t *testing.T) {
+	accessTokenEndpoint := "https://example.com/oauth2/token"
+	conn := &connectionImpl{
+		authType:            "adbc.bigquery.sql.auth_type.user_authentication",
+		catalog:             "test-project-id",
+		dbSchema:            "test-dataset-id",
+		tableID:             "test-table-id",
+		clientID:            "test-client-id",
+		clientSecret:        "test-client-secret",
+		refreshToken:        "test-refresh-token",
+		accessTokenEndpoint: accessTokenEndpoint,
+	}
+
+	err := conn.newClient(context.Background())
+	if err != nil {
+		t.Errorf("Error occurred %v", err)
+	}
+	if conn.accessTokenEndpoint != accessTokenEndpoint {
+		t.Errorf("Expected access token endpoint to be %s, but got %s", accessTokenEndpoint, conn.accessTokenEndpoint)
+	}
+	if conn.accessTokenServerName != "" {
+		t.Errorf("Expected access token server name to be blank, but got %s", conn.accessTokenServerName)
+	}
+}

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -44,6 +44,8 @@ const (
 	OptionStringAuthClientID              = "adbc.bigquery.sql.auth.client_id"
 	OptionStringAuthClientSecret          = "adbc.bigquery.sql.auth.client_secret"
 	OptionStringAuthRefreshToken          = "adbc.bigquery.sql.auth.refresh_token"
+	OptionStringAuthAccessTokenEndpoint   = "adbc.bigquery.sql.auth.access_token_endpoint"
+	OptionStringAuthAccessTokenServerName = "adbc.bigquery.sql.auth.access_token_server_name"
 
 	// OptionStringQueryParameterMode specifies if the query uses positional syntax ("?")
 	// or the named syntax ("@p"). It is illegal to mix positional and named syntax.
@@ -74,8 +76,8 @@ const (
 	defaultQueryResultBufferSize    = 200
 	defaultQueryPrefetchConcurrency = 10
 
-	AccessTokenEndpoint   = "https://accounts.google.com/o/oauth2/token"
-	AccessTokenServerName = "google.com"
+	DefaultAccessTokenEndpoint   = "https://accounts.google.com/o/oauth2/token"
+	DefaultAccessTokenServerName = "google.com"
 )
 
 var (


### PR DESCRIPTION
Exposes the BigQuery OAuth access token endpoint as a config option. This also required exposing the hard-coded `ServerName` used to perform cert validation when getting an access token. Default behavior should remain exactly the same when neither is configured.