### PR TITLE
fix(adbc/driver/snowflake): proposal to enable long buffers for c_str options

### DIFF
--- a/rust/core/src/driver_manager.rs
+++ b/rust/core/src/driver_manager.rs
@@ -377,7 +377,11 @@ where
     F: FnMut(*const c_char, *mut T, *mut usize, *mut ffi::FFI_AdbcError) -> ffi::FFI_AdbcStatusCode,
     T: Default + Clone,
 {
-    const DEFAULT_LENGTH: usize = 128;
+    let default_length = if std::mem::size_of::<T>() == 1 {
+        1024
+    } else {
+        128
+    };
     let key = CString::new(key.as_ref())?;
     let mut run = |length| {
         let mut value = vec![T::default(); length];
@@ -391,10 +395,10 @@ where
         )
     };
 
-    let (status, length, value, error) = run(DEFAULT_LENGTH);
+    let (status, length, value, error) = run(default_length);
     check_status(status, error)?;
 
-    if length <= DEFAULT_LENGTH {
+    if length <= default_length {
         Ok(value[..length].to_vec())
     } else {
         let (status, _, value, error) = run(length);


### PR DESCRIPTION
## Problem
So we need to accommodate fields higher than 128 bytes in some cases. The Go Library is proven to support arbitrary lengths but this Rust layer artificially constrains values. This is a problem because some tokens go well beyond 128-1 bytes (-1 for the null terminator).

This bug was encountered while trying to use `Database::set_option` and `Database::get_option` for a string higher than 128 bytes in length. `Database::set_option` doesn't have this restriction curiously.

## Impact

Without this functionality, we cannot complete native oauth in Snowflake.

Other database configurations with values longer than 128 bytes will not be supported.


## Solution
To always allocate 1024 truly would be overkill. So I'm splitting the difference with 1024 bytes.

I'm stabbing a bit in the dark here but I think the type to override for will be `c_char`.

If you know a more efficient workaround, please, let's do that, not this :D 

