### PR TITLE
adapter: add driver interface fields for use with underlying bigquery sdk.

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -29,6 +29,7 @@ type databaseImpl struct {
 	driverbase.DatabaseImplBase
 
 	authType              string
+	accessToken           string
 	credentials           string
 	clientID              string
 	clientSecret          string

--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -84,6 +84,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.clientID, nil
 	case OptionStringAuthClientSecret:
 		return d.clientSecret, nil
+	case OptionStringAuthAccessToken:
+		return d.accessToken, nil
 	case OptionStringAuthRefreshToken:
 		return d.refreshToken, nil
 	case OptionStringProjectID:
@@ -119,6 +121,8 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 			d.authType = value
 		case OptionValueAuthTypeUserAuthentication:
 			d.authType = value
+		case OptionValueAuthTypeTemporaryAccessToken:
+			d.authType = value
 		default:
 			return adbc.Error{
 				Code: adbc.StatusInvalidArgument,
@@ -131,6 +135,8 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.clientID = value
 	case OptionStringAuthClientSecret:
 		d.clientSecret = value
+	case OptionStringAuthAccessToken:
+		d.accessToken = value
 	case OptionStringAuthRefreshToken:
 		d.refreshToken = value
 	case OptionStringAuthAccessTokenEndpoint:

--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -47,6 +47,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 	conn := &connectionImpl{
 		ConnectionImplBase:     driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
 		authType:               d.authType,
+		accessToken:            d.accessToken,
 		credentials:            d.credentials,
 		clientID:               d.clientID,
 		clientSecret:           d.clientSecret,

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -456,6 +456,8 @@ func (c *connectionImpl) GetOption(key string) (string, error) {
 		return c.authType, nil
 	case OptionStringAuthCredentials:
 		return c.credentials, nil
+	case OptionStringAuthAccessToken:
+		return c.accessToken, nil
 	case OptionStringAuthClientID:
 		return c.clientID, nil
 	case OptionStringAuthClientSecret:

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -45,6 +45,7 @@ type connectionImpl struct {
 	driverbase.ConnectionImplBase
 
 	authType              string
+	accessToken           string
 	credentials           string
 	clientID              string
 	clientSecret          string

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -504,13 +504,20 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		}
 	}
 	switch c.authType {
-	case OptionValueAuthTypeJSONCredentialFile, OptionValueAuthTypeJSONCredentialString, OptionValueAuthTypeUserAuthentication:
+	case OptionValueAuthTypeJSONCredentialFile,
+	    OptionValueAuthTypeJSONCredentialString,
+	    OptionValueAuthTypeUserAuthentication,
+	    OptionValueAuthTypeTemporaryAccessToken:
 		var credentials option.ClientOption
-		if c.authType == OptionValueAuthTypeJSONCredentialFile {
+
+		switch c.authType {
+		case OptionValueAuthTypeJSONCredentialFile:
 			credentials = option.WithCredentialsFile(c.credentials)
-		} else if c.authType == OptionValueAuthTypeJSONCredentialString {
+
+		case OptionValueAuthTypeJSONCredentialString:
 			credentials = option.WithCredentialsJSON([]byte(c.credentials))
-		} else {
+
+		case OptionValueAuthTypeUserAuthentication:
 			if c.clientID == "" {
 				return adbc.Error{
 					Code: adbc.StatusInvalidArgument,
@@ -531,13 +538,25 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 			}
 			if c.accessTokenEndpoint == "" || c.accessTokenEndpoint == DefaultAccessTokenEndpoint {
 				c.accessTokenEndpoint = DefaultAccessTokenEndpoint
-				// Only use default server name if the access token endpoint is also set to default
 				if c.accessTokenServerName == "" {
 					c.accessTokenServerName = DefaultAccessTokenServerName
 				}
 			}
-
 			credentials = option.WithTokenSource(c)
+
+		case OptionValueAuthTypeTemporaryAccessToken:
+			if c.accessToken == "" {
+				return adbc.Error{
+					Code: adbc.StatusInvalidArgument,
+					Msg:  fmt.Sprintf("The `%s` parameter is empty", OptionStringAuthAccessToken),
+				}
+			}
+			credentials = option.WithTokenSource(
+				oauth2.StaticTokenSource(&oauth2.Token{
+					AccessToken: c.accessToken,
+					TokenType:   "Bearer",
+				}),
+			)
 		}
 
 		client, err := bigquery.NewClient(ctx, c.catalog, credentials)
@@ -551,6 +570,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		}
 
 		c.client = client
+
 	default:
 		client, err := bigquery.NewClient(ctx, c.catalog)
 		if err != nil {
@@ -564,6 +584,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 
 		c.client = client
 	}
+
 	return nil
 }
 

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -79,3 +79,36 @@ func TestCustomAccessTokenEndpoint(t *testing.T) {
 		t.Errorf("Expected access token server name to be blank, but got %s", conn.accessTokenServerName)
 	}
 }
+
+func TestTemporaryAccessToken_Valid(t *testing.T) {
+	conn := &connectionImpl{
+		authType:     "adbc.bigquery.sql.auth_type.temporary_access_token",
+		catalog:      "test-project-id",
+		dbSchema:     "test-dataset-id",
+		tableID:      "test-table-id",
+		accessToken:  "ya29.fake-access-token-for-test",
+	}
+
+	err := conn.newClient(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error with valid temporary access token, got: %v", err)
+	}
+}
+
+func TestTemporaryAccessToken_MissingToken(t *testing.T) {
+	conn := &connectionImpl{
+		authType: "adbc.bigquery.sql.auth_type.temporary_access_token",
+		catalog:  "test-project-id",
+		dbSchema: "test-dataset-id",
+		tableID:  "test-table-id",
+		// accessToken intentionally missing
+	}
+
+	err := conn.newClient(context.Background())
+	if err == nil {
+		t.Fatal("Expected error due to missing access token, got nil")
+	}
+	if !strings.Contains(err.Error(), "adbc.bigquery.sql.auth.access_token") {
+		t.Errorf("Expected error message to mention missing access token, got: %v", err)
+	}
+}

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -40,6 +40,9 @@ const (
 	OptionValueAuthTypeJSONCredentialString = "adbc.bigquery.sql.auth_type.json_credential_string"
 	OptionStringAuthCredentials             = "adbc.bigquery.sql.auth_credentials"
 
+	OptionValueAuthTypeTemporaryAccessToken = "adbc.bigquery.sql.auth_type.temporary_access_token"
+	OptionStringAuthAccessToken             = "adbc.bigquery.sql.auth.access_token"
+
 	OptionValueAuthTypeUserAuthentication = "adbc.bigquery.sql.auth_type.user_authentication"
 	OptionStringAuthClientID              = "adbc.bigquery.sql.auth.client_id"
 	OptionStringAuthClientSecret          = "adbc.bigquery.sql.auth.client_secret"


### PR DESCRIPTION
Okay, first time I've worked with Go or done a library change like this. Rip it to shreds as needed heh


Necessary for merging [this commit Craig graciously made](https://github.com/dbt-labs/fs/compare/FDE-305/bigquery-oauth-secrets-temp-token-auth) (it will need slight changes to work after merging this).

## Problem
We need support for using a temporary (non-refreshable) OAuth 2.0 access token via the newly added `adbc.bigquery.sql.auth_type = "adbc.bigquery.sql.auth_type.temporary_access_token"` option.

## Solution
This works by constructing an oauth2.StaticTokenSource from the provided token and passing it to option.WithTokenSource, as recommended by the Google Cloud Go SDK. This enables users to integrate with external token providers, service account impersonation flows, or short-lived federated tokens (e.g. Workload Identity Federation).

## Impact

We will get Bigquery temporary access token auth.

----

### sources for underlying SDK
1. [oauth2.Token](https://pkg.go.dev/golang.org/x/oauth2#Token)
    *  Represents an access token. You use this when creating a static or refreshable token source.
2. [oauth2.StaticTokenSource function](https://pkg.go.dev/golang.org/x/oauth2#StaticTokenSource)
    * Wraps a token in a TokenSource that always returns the same token — perfect for non-refreshable, short-lived access tokens (like those from service account impersonation or external auth systems).
3. [option.WithTokenSource]( https://pkg.go.dev/google.golang.org/api/option#WithTokenSource)
    *  Apparently this is the standard way to inject a token source into any Google Cloud Go client (e.g. BigQuery).

### aside
Interestingly, the Python bigquery client does half of this for you; you just give the `Client` the `token` and `refreshToken` as fields on the object, whereas here we need to explicitly wrap it to work with the underlying library.