### PR TITLE
Add Ingestion to Execute API

### DIFF
--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -81,6 +81,9 @@ const (
 
 	DefaultAccessTokenEndpoint   = "https://accounts.google.com/o/oauth2/token"
 	DefaultAccessTokenServerName = "google.com"
+
+	OptionStringIngestFileDelimiter = "adbc.bigquery.ingest_file_delimiter"
+	OptionStringIngestPath          = "adbc.bigquery.ingest_path"
 )
 
 var (

--- a/go/adbc/driver/bigquery/driver_test.go
+++ b/go/adbc/driver/bigquery/driver_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -1512,6 +1513,116 @@ func (suite *BigQueryTests) TestMetadataGetObjectsColumnsXdbc() {
 	suite.ElementsMatch(expectedXdbcIsGeneratedColumn, xdbcIsGeneratedColumn)
 	suite.ElementsMatch(expectedConstraints, constraints)
 
+}
+
+func (suite *BigQueryTests) TestStatementExecuteQueryIngest() {
+	ctx := context.Background()
+	conn := suite.cnxn
+	defer conn.Close()
+
+	// Create a temporary CSV file for testing
+	tmpFile, err := os.CreateTemp("", "test_ingest_*.csv")
+	suite.Require().NoError(err)
+	defer os.Remove(tmpFile.Name())
+
+	// Write test data
+	_, err = tmpFile.WriteString("id,name\n1,test1\n2,test2\n")
+	suite.Require().NoError(err)
+	tmpFile.Close()
+
+	// Test cases
+	tests := []struct {
+		name          string
+		setup         func(stmt adbc.Statement) error
+		expectedError string
+	}{
+		{
+			name: "basic ingest with default settings",
+			setup: func(stmt adbc.Statement) error {
+				err := stmt.SetOption(driver.OptionStringIngestPath, tmpFile.Name())
+				if err != nil {
+					return err
+				}
+				return stmt.SetOption(adbc.OptionKeyIngestMode, adbc.OptionValueIngestModeCreateAppend)
+			},
+		},
+		{
+			name: "ingest with custom delimiter",
+			setup: func(stmt adbc.Statement) error {
+				err := stmt.SetOption(driver.OptionStringIngestPath, tmpFile.Name())
+				if err != nil {
+					return err
+				}
+				err = stmt.SetOption(driver.OptionStringIngestFileDelimiter, ";")
+				if err != nil {
+					return err
+				}
+				return stmt.SetOption(adbc.OptionKeyIngestMode, adbc.OptionValueIngestModeCreateAppend)
+			},
+		},
+		{
+			name: "ingest with replace mode",
+			setup: func(stmt adbc.Statement) error {
+				err := stmt.SetOption(driver.OptionStringIngestPath, tmpFile.Name())
+				if err != nil {
+					return err
+				}
+				return stmt.SetOption(adbc.OptionKeyIngestMode, adbc.OptionValueIngestModeReplace)
+			},
+		},
+		{
+			name: "ingest without file path",
+			setup: func(stmt adbc.Statement) error {
+				return stmt.SetOption(adbc.OptionKeyIngestMode, adbc.OptionValueIngestModeCreateAppend)
+			},
+			expectedError: "cannot execute ingest without a file path",
+		},
+		{
+			name: "ingest with invalid mode",
+			setup: func(stmt adbc.Statement) error {
+				err := stmt.SetOption(driver.OptionStringIngestPath, tmpFile.Name())
+				if err != nil {
+					return err
+				}
+				return stmt.SetOption(adbc.OptionKeyIngestMode, "invalid_mode")
+			},
+			expectedError: "unsupported ingest mode",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			stmt, err := conn.NewStatement()
+			suite.Require().NoError(err)
+			defer stmt.Close()
+
+			// Set destination table
+			err = stmt.SetOption(driver.OptionStringQueryDestinationTable, "test_ingest")
+			suite.Require().NoError(err)
+
+			// Run setup
+			err = tt.setup(stmt)
+			suite.Require().NoError(err)
+
+			// Execute query
+			reader, affected, err := stmt.ExecuteQuery(ctx)
+
+			if tt.expectedError != "" {
+				suite.Error(err)
+				suite.Contains(err.Error(), tt.expectedError)
+				return
+			}
+
+			suite.Require().NoError(err)
+			suite.Require().NotNil(reader)
+			suite.Equal(int64(0), affected) // Ingest operations return 0 affected rows
+
+			// Verify empty result set
+			suite.False(reader.Next())
+			suite.NoError(reader.Err())
+			reader.Release()
+		})
+	}
 }
 
 var _ validation.DriverQuirks = (*BigQueryQuirks)(nil)

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -20,6 +20,7 @@ package bigquery
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -51,6 +52,11 @@ type statement struct {
 	streamBinding          array.RecordReader
 	resultRecordBufferSize int
 	prefetchConcurrency    int
+
+	// Ingest related fields
+	isIngest     bool
+	ingestPath   string
+	ingestFileDelimiter string
 }
 
 func (st *statement) GetOptionBytes(key string) ([]byte, error) {
@@ -132,6 +138,11 @@ func (st *statement) GetOption(key string) (string, error) {
 		return strconv.FormatBool(st.queryConfig.DryRun), nil
 	case OptionBoolQueryCreateSession:
 		return strconv.FormatBool(st.queryConfig.CreateSession), nil
+	case OptionStringIngestFileDelimiter:
+		return st.ingestFileDelimiter, nil
+	case OptionStringIngestPath:
+		return st.ingestPath, nil
+
 	default:
 		val, err := st.cnxn.GetOption(key)
 		if err == nil {
@@ -248,7 +259,23 @@ func (st *statement) SetOption(key string, v string) error {
 		} else {
 			return err
 		}
-
+	case OptionStringIngestPath:
+		st.isIngest = true
+		st.ingestPath = v
+	case OptionStringIngestFileDelimiter:
+		st.ingestFileDelimiter = v
+	case adbc.OptionKeyIngestMode:
+		switch v {
+		case adbc.OptionValueIngestModeCreateAppend,  adbc.OptionValueIngestModeAppend:
+			st.queryConfig.WriteDisposition = bigquery.WriteAppend
+		case adbc.OptionValueIngestModeReplace:
+			st.queryConfig.WriteDisposition = bigquery.WriteTruncate
+		default:
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("unsupported ingest mode `%s`", v),
+			}
+		}
 	default:
 		return adbc.Error{
 			Code: adbc.StatusInvalidArgument,
@@ -297,6 +324,10 @@ func (st *statement) SetSqlQuery(query string) error {
 //
 // This invalidates any prior result sets on this statement.
 func (st *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, int64, error) {
+	if st.isIngest {
+		return st.executeIngest(ctx)
+	}
+
 	if st.queryConfig.Q == "" {
 		return nil, -1, adbc.Error{
 			Msg:  "cannot execute without a query",
@@ -493,6 +524,121 @@ func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.Sta
 			Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", value.DataType().ID()),
 		}
 	}
+}
+
+func arrowFieldToBigQueryField(arrowField arrow.Field) (bigquery.FieldSchema, error) {
+	switch arrowField.Type.ID() {
+		case arrow.BOOL:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type: bigquery.StringFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.IntegerFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.FloatFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.BINARY, arrow.BINARY_VIEW, arrow.LARGE_BINARY, arrow.FIXED_SIZE_BINARY:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.BytesFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.STRING, arrow.STRING_VIEW, arrow.LARGE_STRING:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.StringFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.TIMESTAMP:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.TimestampFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.TIME32, arrow.TIME64:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.TimeFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.DECIMAL128:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.NumericFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.DECIMAL256:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.BigNumericFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+			elemField := arrowField.Type.(*arrow.ListType).ElemField()
+			elemType, err := arrowFieldToBigQueryField(elemField)
+			if err != nil {
+				return bigquery.FieldSchema{}, err
+			}
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     elemType.Type,
+				Required: !arrowField.Nullable,
+				Repeated: true,
+			}, nil
+		case arrow.STRUCT:
+			// ToDo: implement structs schema generation
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.RecordFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		default:
+			// todo: implement all other types
+			//
+			// - arrow.DURATION
+			//   For arrow.DURATION, I'm not sure which SQL DataType would be a good
+			//   representation for it. `DATETIME` could be a potential one for it,
+			//   if we count from `0000-01-01T00:00:00.000000Z`
+			//
+			// - arrow.INTERVAL_MONTHS
+			// - arrow.INTERVAL_DAY_TIME
+			// - arrow.INTERVAL_MONTH_DAY_NANO
+			//   `DATETIME` could be a potential fit for all interval types, but
+			//   the issue is there's no rules about how many days are in a month.
+			//
+			// - arrow.RUN_END_ENCODED
+			// - arrow.SPARSE_UNION
+			// - arrow.DENSE_UNION
+			// - arrow.DICTIONARY
+			// - arrow.MAP
+			return bigquery.FieldSchema{}, adbc.Error{
+				Code: adbc.StatusNotImplemented,
+				Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", arrowField.Type.ID()),
+			}
+	}
+}
+
+// arrowSchemaToBigQuery converts an Arrow schema to a BigQuery schema
+func arrowSchemaToBigQuery(schema *arrow.Schema) (bigquery.Schema, error) {
+	bqSchema := make(bigquery.Schema, len(schema.Fields()))
+	for i, field := range schema.Fields() {
+		bqField, err := arrowFieldToBigQueryField(field)
+		if err != nil {
+			return nil, err
+		}
+
+		bqSchema[i] = &bqField
+	}
+	return bqSchema, nil
 }
 
 func arrowValueToQueryParameterValue(field arrow.Field, value arrow.Array, i int) (bigquery.QueryParameter, error) {
@@ -774,6 +920,68 @@ func (st *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc
 		Code: adbc.StatusNotImplemented,
 		Msg:  "ExecutePartitions not yet implemented for BigQuery driver",
 	}
+}
+
+func (st *statement) initIngest(ctx context.Context) error {
+	if st.ingestPath == "" {
+		return adbc.Error{
+			Code: adbc.StatusInvalidState,
+			Msg:  "cannot execute ingest without a file path",
+		}
+	}
+
+	// Open the local file
+	file, err := os.Open(st.ingestPath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	// Create a reader source from the file
+	loadSource := bigquery.NewReaderSource(file)
+	job := st.queryConfig.Dst.LoaderFrom(loadSource)
+
+	// Configure the load job
+	job.WriteDisposition = st.queryConfig.WriteDisposition
+
+	// Set file format configuration
+	job.Src.(*bigquery.ReaderSource).FileConfig.SourceFormat = bigquery.CSV
+	job.Src.(*bigquery.ReaderSource).FileConfig.SkipLeadingRows = 1  // Skip header row
+	job.Src.(*bigquery.ReaderSource).FileConfig.FieldDelimiter = st.ingestFileDelimiter // Default CSV delimiter
+
+	// Convert Arrow schema to BigQuery schema if provided
+	if st.paramBinding != nil {
+		bqSchema, err := arrowSchemaToBigQuery(st.paramBinding.Schema())
+		if err != nil {
+			return fmt.Errorf("failed to convert schema: %w", err)
+		}
+		job.Src.(*bigquery.ReaderSource).FileConfig.Schema = bqSchema
+	}
+
+	// Run the load job
+	_, err = job.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run load job: %w", err)
+	}
+
+	return nil
+}
+
+func (st *statement) executeIngest(ctx context.Context) (array.RecordReader, int64, error) {
+	err := st.initIngest(ctx)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	// For ingest operations, we return an empty record reader since there's no result set
+	emptySchema := arrow.NewSchema([]arrow.Field{}, nil)
+	emptyRecord := array.NewRecord(emptySchema, []arrow.Array{}, 0)
+	reader, err := array.NewRecordReader(emptySchema, []arrow.Record{emptyRecord})
+	if err != nil {
+		return nil, -1, err
+	}
+
+	return reader, 0, nil
 }
 
 var _ adbc.GetSetOptions = (*statement)(nil)


### PR DESCRIPTION
- **fix: Use number of rows (rather than schema) to check if we need an empty arrow iterator (#1)**
- **feat(go/adbc/driver/bigquery): Return data about table/view partitioning (#2697)**
- **feat(go/adbc/driver/bigquery): Make OAuth access token endpoint configurable (#5)**
- **go(adbc/driver/snowflake): Add 3 OAuth-related parameters**
- **fix(adbc/driver/snowflake): proposal to allow for longer string buffers for c_str options**
- **fix(adbc/driver/snowflake): implement ability to set a single database option**
- **fix(rust/core): remove the Mutex around the FFI driver object (#10)**
- **feat(go/adbc/driver/databricks): Initial version of the Databricks driver in Go (#3)**
- **adapter: add driver interface fields for use with underlying bigquery sdk. (#11)**
- **add ingestion parameters**
