### PR TITLE
fix(go/adbc/driver/databricks): Add new error constructor that sets SQLSTATE

### DIFF
--- a/go/adbc/driver/databricks/cmd_record_reader.go
+++ b/go/adbc/driver/databricks/cmd_record_reader.go
@@ -130,10 +130,10 @@ func (r *commandReader) setRecord() {
 			rows := results.Data.([]interface{})
 			r.rec, r.err = BuildFromRows(r.schema, rows)
 		default:
-			r.err = adbc.Error{
-				Code: adbc.StatusInvalidData,
-				Msg:  fmt.Sprintf("Unexpected command result type: %T", results.Data),
-			}
+			r.err = NewAdbcError(
+				fmt.Sprintf("Unexpected command result type: %T", results.Data),
+				adbc.StatusInvalidData,
+			)
 		}
 
 	} else if results.ResultType == compute.ResultTypeText {
@@ -143,17 +143,17 @@ func (r *commandReader) setRecord() {
 		rows := results.Data.([]interface{})
 		r.rec, r.err = BuildFromRows(schema, rows)
 	} else {
-		r.err = adbc.Error{
-			Code: adbc.StatusInvalidData,
-			Msg:  fmt.Sprintf("Unexpected command result type: %s", results.ResultType),
-		}
+		r.err = NewAdbcError(
+			fmt.Sprintf("Unexpected command result type: %s", results.ResultType),
+			adbc.StatusInvalidData,
+		)
 	}
 }
 
 // \post: if returns true, r.Record() != nil && r.err == nil
 // \post: if returns false, r.Record() == nil and r.err *MUST* be checked
 func (r *commandReader) Next() bool {
-	
+
 	if r.rec == nil {
 		r.setRecord()
 		if r.err == nil {

--- a/go/adbc/driver/databricks/connection.go
+++ b/go/adbc/driver/databricks/connection.go
@@ -112,10 +112,10 @@ func (conn *connectionImpl) SetAutocommit(enabled bool) error {
 	if enabled {
 		return nil
 	}
-	return adbc.Error{
-		Code: adbc.StatusNotImplemented,
-		Msg:  "SetAutocommit to `false` is not yet implemented",
-	}
+	return NewAdbcError(
+		"SetAutocommit to `false` is not yet implemented",
+		adbc.StatusNotImplemented,
+	)
 }
 
 // }}}

--- a/go/adbc/driver/databricks/databricks_database.go
+++ b/go/adbc/driver/databricks/databricks_database.go
@@ -40,15 +40,15 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 	client, err := databricks.NewWorkspaceClient(d.config)
 	if err != nil {
 		if err == databricks.ErrNotWorkspaceClient {
-			return nil, adbc.Error{
-				Code: adbc.StatusInvalidArgument,
-				Msg:  "[Databricks] " + err.Error(),
-			}
+			return nil, NewAdbcError(
+				"[Databricks] " + err.Error(),
+				adbc.StatusInvalidArgument,
+			)
 		}
-		return nil, adbc.Error{
-			Code: adbc.StatusUnknown,
-			Msg:  "[Databricks] " + err.Error(),
-		}
+		return nil, NewAdbcError(
+			"[Databricks] " + err.Error(),
+			adbc.StatusUnknown,
+		)
 	}
 	mode := ""
 	if d.config.WarehouseID != "" {

--- a/go/adbc/driver/databricks/error.go
+++ b/go/adbc/driver/databricks/error.go
@@ -1,0 +1,31 @@
+package databricks
+
+import (
+    "regexp"
+    "strings"
+
+    "github.com/apache/arrow-adbc/go/adbc"
+)
+
+const unknownVendorCode = int32(-1) // sentinel value for vendor code; databricks doesn't populate
+
+var (
+    sqlstateRE               = regexp.MustCompile(`(?i)SQLSTATE:\s*([A-Z0-9]{5})`)
+    defaultSQLStateErrorCode = [5]byte{'H', 'Y', '0', '0', '0'} // general error
+)
+
+func NewAdbcError(msg string, code adbc.Status) adbc.Error {
+    sqlstate := defaultSQLStateErrorCode
+
+    if m := sqlstateRE.FindStringSubmatch(msg); len(m) == 2 {
+        copy(sqlstate[:], strings.ToUpper(m[1]))
+    }
+
+    return adbc.Error{
+        Msg:        msg,
+        Code:       code,
+        VendorCode: unknownVendorCode,
+        SqlState:   sqlstate,
+        Details:    nil,
+    }
+}

--- a/go/adbc/driver/databricks/stmt_record_reader.go
+++ b/go/adbc/driver/databricks/stmt_record_reader.go
@@ -283,15 +283,21 @@ func (r *statementReader) Err() error {
 		return nil
 	}
 	if errors.Is(r.err, context.Canceled) {
-		return adbc.Error{Msg: r.err.Error(), Code: adbc.StatusCancelled}
+		return NewAdbcError(
+			r.err.Error(),
+			adbc.StatusCancelled,
+		)
 	}
 	if errors.Is(r.err, context.DeadlineExceeded) {
-		return adbc.Error{Msg: r.err.Error(), Code: adbc.StatusTimeout}
+		return NewAdbcError(
+			r.err.Error(),
+			adbc.StatusTimeout,
+		)
 	}
-	return adbc.Error{
-		Msg:  r.err.Error(),
-		Code: adbc.StatusUnknown,
-	}
+	return NewAdbcError(
+		r.err.Error(),
+		adbc.StatusUnknown,
+	)
 }
 
 func (r *statementReader) Throughput() float64 {


### PR DESCRIPTION
solves https://github.com/dbt-labs/fs/issues/2989
related to #15 
sequel to #3 and #22 

## Description

Pass SQLSTATE for Databricks through to Rust for better errors.

Slice out the SQLSTATE from Include fallback vendor code and error string. 

Keep regex for extracting SQLSTATE embedded error message, which is what dbx likes to do, strict in what's permissible since we're  taking precisely 5 bytes following the SQLSTATE string.

## Testing

Tests in `dbt-adapter` for databricks: `cargo xtask test adapters::databricks::`.

Error behavior thoroughly manually tested. 

Italics are strictly commentary.

### 1. Current state

<img width="987" alt="Screenshot 2025-05-30 at 1 11 05 AM" src="https://github.com/user-attachments/assets/c72baaea-06b6-4220-9045-1aa9bfc8b02d" />

Always defaults to "00000" for SQL status.

### 2. New and improved state

We now pass the `SQLSTATE` values through and the Rust `AdbcError::From` is able to render the correct error message string!

<img width="987" alt="Screenshot 2025-05-30 at 1 33 53 AM" src="https://github.com/user-attachments/assets/8a78769f-e3cd-4148-aa5e-0d05685e127b" />

### 3. Also simulated is the fallback case for all future errors

<img width="987" alt="Screenshot 2025-05-30 at 1 14 07 AM" src="https://github.com/user-attachments/assets/162e1611-8051-4904-9c8f-d3255204a26b" />


