### PR TITLE
fix(go/adbc/driver/snowflake): add the _ to - conversion at this level to catch all possible instantiations

### DIFF
--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -209,7 +209,7 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 	case OptionRegion:
 		d.cfg.Region = v
 	case OptionAccount:
-		d.cfg.Account = v
+		d.cfg.Account = strings.ReplaceAll(v, "_", "-")
 	case OptionProtocol:
 		d.cfg.Protocol = v
 	case OptionHost:

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -209,6 +209,10 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 	case OptionRegion:
 		d.cfg.Region = v
 	case OptionAccount:
+		// Snowflake accepts both '_' and '-' in account identifiers, but only '-' works in hostnames.
+		// This inconsistency is Snowflake's choice, even though it conflicts with TLS/SSL grammar:
+		// https://docs.snowflake.com/en/user-guide/admin-account-identifier
+		// https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1
 		d.cfg.Account = strings.ReplaceAll(v, "_", "-")
 	case OptionProtocol:
 		d.cfg.Protocol = v

--- a/go/adbc/driver/snowflake/snowflake_database_test.go
+++ b/go/adbc/driver/snowflake/snowflake_database_test.go
@@ -27,7 +27,11 @@ import (
 func TestSetOptionInternal_NormalizesAccount(t *testing.T) {
 	db := &databaseImpl{cfg: &gosnowflake.Config{}}
 
-	err := db.SetOptionInternal(OptionAccount, "my_account_name", nil)
-	require.NoError(t, err)
+	err_a := db.SetOptionInternal(OptionAccount, "my_account_name", nil)
+	require.NoError(t, err_a)
+	require.Equal(t, "my-account-name", db.cfg.Account)
+
+	err_b := db.SetOptionInternal(OptionAccount, "my-account_name", nil)
+	require.NoError(t, err_b)
 	require.Equal(t, "my-account-name", db.cfg.Account)
 }

--- a/go/adbc/driver/snowflake/snowflake_database_test.go
+++ b/go/adbc/driver/snowflake/snowflake_database_test.go
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/snowflakedb/gosnowflake"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetOptionInternal_NormalizesAccount(t *testing.T) {
+	db := &databaseImpl{cfg: &gosnowflake.Config{}}
+
+	err := db.SetOptionInternal(OptionAccount, "my_account_name", nil)
+	require.NoError(t, err)
+	require.Equal(t, "my-account-name", db.cfg.Account)
+}


### PR DESCRIPTION
Proposing we push down https://github.com/dbt-labs/fs/pull/3709 to this layer.

- Treat this fix as more of an SSL/TLS layer fix.
- One place to normalize all account strings
- Prevent future `fs` engi from forgetting this step if they ever use the account string anywhere and forget to match the normalization

This makes the user see the account string as normalized only at the connection layer. Their character for character account string will appear everywhere else making it easier to reason about too.