### PR TITLE
 chore(go/adbc/driver/snowflake): Update adbc driver and version of gosnowflake

### DIFF
--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/databricks/databricks-sdk-go v0.62.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/snowflakedb/gosnowflake v1.14.0
+	github.com/snowflakedb/gosnowflake v1.14.1
 	github.com/stretchr/testify v1.10.0
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
@@ -41,7 +41,7 @@ require (
 	modernc.org/sqlite v1.37.0
 )
 
-replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.14.1-0.20250527140352-9b93f4918cc1
+replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.14.1
 
 require (
 	cloud.google.com/go v0.118.3 // indirect

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -103,8 +103,8 @@ github.com/databricks/databricks-sdk-go v0.62.0/go.mod h1:xBtjeP9nq+6MgTewZW1Ecb
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dbt-labs/gosnowflake v1.14.1-0.20250527140352-9b93f4918cc1 h1:xM5ihAvn6aEFSXqKVFcl5P6IAhj7ngQBGYsb/RsiPOQ=
-github.com/dbt-labs/gosnowflake v1.14.1-0.20250527140352-9b93f4918cc1/go.mod h1:FXhaEQFoOTKFoMGrPy6LfNVrotqUHpC2q3m9zlhDetk=
+github.com/dbt-labs/gosnowflake v1.14.1 h1:nAT9vw88GxJc1kelYeSwwOWKGjjJz+p1Ju6xBz8B2j0=
+github.com/dbt-labs/gosnowflake v1.14.1/go.mod h1:FXhaEQFoOTKFoMGrPy6LfNVrotqUHpC2q3m9zlhDetk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.7.0 h1:bnQc8+GMnidJZA8zc6lLEAb4xNrIqHwO+9TzqvtQZPo=


### PR DESCRIPTION
## ADBC driver

release after this merge will include the `_ => -` #24 

## Flock based token caching 
I created v1.14.1 and pushed it. [Here's a link](https://github.com/dbt-labs/gosnowflake/commit/c0afd49ce1543e420d4ab8f678b36c8db6849de2).

