### PR TITLE
feat(go/adbc/driver/databricks) Add external browser auth

### DIFF
--- a/go/adbc/driver/databricks/databricks_database.go
+++ b/go/adbc/driver/databricks/databricks_database.go
@@ -37,16 +37,23 @@ type databaseImpl struct {
 }
 
 func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
+	// Set up external browser credentials strategy if external-browser auth type is used
+	if d.config.AuthType == OptionValueAuthTypeExternalBrowser {
+		d.config.Credentials = &ExternalBrowserCredentials{
+			Host:     d.config.Host,
+			ClientID: d.config.ClientID,
+		}
+	}
 	client, err := databricks.NewWorkspaceClient(d.config)
 	if err != nil {
 		if err == databricks.ErrNotWorkspaceClient {
 			return nil, NewAdbcError(
-				"[Databricks] " + err.Error(),
+				"[Databricks] "+err.Error(),
 				adbc.StatusInvalidArgument,
 			)
 		}
 		return nil, NewAdbcError(
-			"[Databricks] " + err.Error(),
+			"[Databricks] "+err.Error(),
 			adbc.StatusUnknown,
 		)
 	}

--- a/go/adbc/driver/databricks/driver.go
+++ b/go/adbc/driver/databricks/driver.go
@@ -36,6 +36,7 @@ const (
 	OptionValueAuthTypeAzureCLI          = "azure-cli"
 	OptionValueAuthTypeAzureMSI          = "azure-msi"
 	OptionValueAuthTypeAzureClientSecret = "azure-client-secret"
+	OptionValueAuthTypeExternalBrowser   = "external-browser"
 
 	OptionStringCluster             = "adbc.databricks.cluster"
 	OptionStringWarehouse           = "adbc.databricks.warehouse"
@@ -58,7 +59,7 @@ const (
 	OptionStringUsername  = "username"
 	OptionStringPassword  = "password"
 
-	// The Databricks service principal’s client ID and secret.
+	// The Databricks service principal's client ID and secret.
 	OptionStringClientID     = "adbc.databricks.client_id"
 	OptionStringClientSecret = "adbc.databricks.client_secret"
 

--- a/go/adbc/driver/databricks/external_browser_credentials.go
+++ b/go/adbc/driver/databricks/external_browser_credentials.go
@@ -20,6 +20,7 @@ package databricks
 import (
 	"context"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"net/url"
@@ -106,7 +107,6 @@ func (c *ExternalBrowserCredentials) Configure(ctx context.Context, cfg *config.
 		c.RedirectURI = defaultRedirectURI
 	}
 
-	fmt.Printf("External browser authentication completed successfully.\n")
 	return c.createCredentialsProvider(), nil
 }
 
@@ -171,7 +171,9 @@ func (c *ExternalBrowserCredentials) performOAuthFlow(ctx context.Context) (*oau
 
 			if errorParam != "" {
 				errorDesc := r.URL.Query().Get("error_description")
-				fmt.Fprintf(w, browserErrorWithDescHtml, errorParam, errorDesc)
+				escapedError := html.EscapeString(errorParam)
+				escapedErrorDesc := html.EscapeString(errorDesc)
+				fmt.Fprintf(w, browserErrorWithDescHtml, escapedError, escapedErrorDesc)
 				errorChan <- fmt.Errorf("oauth error: %s - %s", errorParam, errorDesc)
 				return
 			}

--- a/go/adbc/driver/databricks/external_browser_credentials.go
+++ b/go/adbc/driver/databricks/external_browser_credentials.go
@@ -41,7 +41,6 @@ const (
 	defaultPort              = 8020
 	tokenPath                = "oidc/v1/token"
 	authorizePath            = "oidc/v1/authorize"
-	expirationBuffer         = 5 * time.Minute
 	browserErrorWithDescHtml = `
 <!DOCTYPE html>
 <html>
@@ -83,11 +82,11 @@ const (
 
 // ExternalBrowserCredentials implements CredentialsStrategy for OAuth 2 PKCE flow for external browser authentication
 // https://github.com/databricks/databricks-sdk-go/blob/56af964ae7d5f86bd454dfdba4edac42aac4d19f/config/config.go#L26
-// TODO(jasonlin45): add os/fs based caching for multi-driver concurrency scenarios and session persistence
 type ExternalBrowserCredentials struct {
 	Host        string
 	ClientID    string
 	RedirectURI string
+	tokenCache  *TokenCache
 }
 
 // From CredentialsStrategy interface
@@ -107,19 +106,74 @@ func (c *ExternalBrowserCredentials) Configure(ctx context.Context, cfg *config.
 		c.RedirectURI = defaultRedirectURI
 	}
 
+	tokenCache, err := NewTokenCache()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize token cache: %w", err)
+	}
+	c.tokenCache = tokenCache
+
 	return c.createCredentialsProvider(), nil
+}
+
+// getOrRefreshCachedToken attempts to retrieve and optionally refresh a cached token
+func (c *ExternalBrowserCredentials) getOrRefreshCachedToken(ctx context.Context) (*oauth2.Token, error) {
+	if c.tokenCache == nil {
+		return nil, fmt.Errorf("token cache not initialized")
+	}
+
+	entry, err := c.tokenCache.LoadToken(ctx, c.Host, c.ClientID)
+	if err != nil {
+		return c.performOAuthFlow(ctx)
+	}
+
+	if entry.RefreshToken != "" {
+		refreshedToken, err := c.performTokenRefresh(ctx, entry.RefreshToken)
+		if err == nil {
+			// Save refreshed token to cache
+			if cacheErr := c.tokenCache.SaveToken(ctx, refreshedToken, c.Host, c.ClientID); cacheErr != nil {
+				logger.Warnf(ctx, "failed to save refreshed token to cache: %v", cacheErr)
+			}
+			return refreshedToken, nil
+		}
+		logger.Warnf(ctx, "token refresh failed, falling back to full OAuth flow: %v", err)
+	}
+
+	return c.performOAuthFlow(ctx)
 }
 
 // creates a CredentialsProvider that uses our access token
 func (c *ExternalBrowserCredentials) createCredentialsProvider() credentials.CredentialsProvider {
 	// TokenSourceFn wraps a token fetching function to be invoked for getting new tokens
 	tokenSource := auth.TokenSourceFn(func(ctx context.Context) (*oauth2.Token, error) {
-		// TODO(jasonlin45): handle refresh token here
-		return c.performOAuthFlow(ctx)
+		return c.getOrRefreshCachedToken(ctx)
 	})
 
 	cachedTokenSource := auth.NewCachedTokenSource(tokenSource)
 	return credentials.NewOAuthCredentialsProviderFromTokenSource(cachedTokenSource)
+}
+
+// base OAuth2 config
+func (c *ExternalBrowserCredentials) buildOAuth2Config() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID: c.ClientID,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: c.buildTokenURL(),
+		},
+		Scopes: []string{"all-apis", "offline_access"},
+	}
+}
+
+func (c *ExternalBrowserCredentials) buildOAuth2ConfigWithAuth(redirectURI string) *oauth2.Config {
+	config := c.buildOAuth2Config()
+	config.Endpoint.AuthURL = c.buildAuthBaseURL()
+	config.RedirectURL = redirectURI
+	return config
+}
+
+func (c *ExternalBrowserCredentials) buildOAuth2ConfigWithRedirect(redirectURI string) *oauth2.Config {
+	config := c.buildOAuth2Config()
+	config.RedirectURL = redirectURI
+	return config
 }
 
 // builds the token endpoint URL with proper protocol scheme
@@ -145,15 +199,7 @@ func (c *ExternalBrowserCredentials) performOAuthFlow(ctx context.Context) (*oau
 	port := c.findAvailablePort()
 	redirectURI := fmt.Sprintf("http://localhost:%d", port)
 
-	config := &oauth2.Config{
-		ClientID: c.ClientID,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  c.buildAuthBaseURL(),
-			TokenURL: c.buildTokenURL(),
-		},
-		RedirectURL: redirectURI,
-		Scopes:      []string{"all-apis", "offline_access"},
-	}
+	config := c.buildOAuth2ConfigWithAuth(redirectURI)
 
 	authURL := config.AuthCodeURL(state,
 		oauth2.S256ChallengeOption(verifier),
@@ -229,7 +275,39 @@ func (c *ExternalBrowserCredentials) performOAuthFlow(ctx context.Context) (*oau
 	server.Shutdown(ctx)
 
 	// Exchange code for tokens
-	return c.exchangeCodeForTokens(ctx, authCode, verifier, redirectURI)
+	token, err := c.exchangeCodeForTokens(ctx, authCode, verifier, redirectURI)
+	if err != nil {
+		return nil, err
+	}
+
+	// Save token to cache for future use
+	if c.tokenCache != nil {
+		if cacheErr := c.tokenCache.SaveToken(ctx, token, c.Host, c.ClientID); cacheErr != nil {
+			// Log warning but don't fail the OAuth flow
+			logger.Warnf(ctx, "failed to save token to cache: %v", cacheErr)
+		}
+	}
+
+	return token, nil
+}
+
+// performTokenRefresh refreshes a token using the refresh token
+func (c *ExternalBrowserCredentials) performTokenRefresh(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
+	config := c.buildOAuth2Config()
+
+	// Create a token with just the refresh token to use for refreshing
+	token := &oauth2.Token{
+		RefreshToken: refreshToken,
+	}
+
+	// Use the token source to refresh
+	tokenSource := config.TokenSource(ctx, token)
+	refreshedToken, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	return refreshedToken, nil
 }
 
 // findAvailablePort finds an available port starting from the default
@@ -242,13 +320,13 @@ func (c *ExternalBrowserCredentials) findAvailablePort() int {
 	// Try ports in a reasonable range
 	for port := defaultPort + 1; port < defaultPort+100; port++ {
 		if c.isPortAvailable(port) {
-			fmt.Printf("Port %d was in use, using port %d instead.\n", defaultPort, port)
+			logger.Infof(context.Background(), "Port %d was in use, using port %d instead", defaultPort, port)
 			return port
 		}
 	}
 
 	// If we can't find any available port, return the default and let it fail with a clear error
-	fmt.Printf("Warning: Could not find an available port, using default port %d.\n", defaultPort)
+	logger.Warnf(context.Background(), "Could not find an available port, using default port %d", defaultPort)
 	return defaultPort
 }
 
@@ -274,14 +352,7 @@ func (c *ExternalBrowserCredentials) buildAuthBaseURL() string {
 
 // exchangeCodeForTokens exchanges the authorization code for access/refresh tokens
 func (c *ExternalBrowserCredentials) exchangeCodeForTokens(ctx context.Context, code, codeVerifier, redirectURI string) (*oauth2.Token, error) {
-	config := &oauth2.Config{
-		ClientID: c.ClientID,
-		Endpoint: oauth2.Endpoint{
-			TokenURL: c.buildTokenURL(),
-		},
-		RedirectURL: redirectURI,
-		Scopes:      []string{"all-apis", "offline_access"},
-	}
+	config := c.buildOAuth2ConfigWithRedirect(redirectURI)
 
 	// exchange for token with PKCE
 	return config.Exchange(ctx, code,

--- a/go/adbc/driver/databricks/external_browser_credentials.go
+++ b/go/adbc/driver/databricks/external_browser_credentials.go
@@ -1,0 +1,305 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package databricks
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/config/credentials"
+	"github.com/databricks/databricks-sdk-go/config/experimental/auth"
+	"github.com/databricks/databricks-sdk-go/logger"
+	"github.com/pkg/browser"
+	"golang.org/x/oauth2"
+)
+
+const (
+	defaultClientID          = "dbt-databricks"
+	defaultRedirectURI       = "http://localhost:8020"
+	defaultPort              = 8020
+	tokenPath                = "oidc/v1/token"
+	authorizePath            = "oidc/v1/authorize"
+	expirationBuffer         = 5 * time.Minute
+	browserErrorWithDescHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Databricks Authentication - Error</title>
+</head>
+<body>
+    <h1>Authentication Failed</h1>
+    <p>Error: %s</p>
+    <p>Description: %s</p>
+    <p>You can close this window and try again.</p>
+</body>
+</html>`
+	browserErrorGenericHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Databricks Authentication - Error</title>
+</head>
+<body>
+    <h1>Authentication Failed</h1>
+    <p>No authorization code received.</p>
+    <p>You can close this window and try again.</p>
+</body>
+</html>
+`
+	browserSuccessHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Databricks Authentication - Success</title>
+</head>
+<body>
+    <h1>Login Successful!</h1>
+    <p>You can close this window and return to your application.</p>
+</body>
+</html>`
+)
+
+// ExternalBrowserCredentials implements CredentialsStrategy for OAuth 2 PKCE flow for external browser authentication
+// TODO(jasonlin45): add os/fs based caching for multi-driver concurrency scenarios and session persistence
+type ExternalBrowserCredentials struct {
+	Host        string
+	ClientID    string
+	RedirectURI string
+}
+
+// From CredentialsStrategy interface
+func (c *ExternalBrowserCredentials) Name() string {
+	return "external-browser"
+}
+
+// From CredentialsStrategy interface
+func (c *ExternalBrowserCredentials) Configure(ctx context.Context, cfg *config.Config) (credentials.CredentialsProvider, error) {
+	if c.Host == "" && cfg.Host != "" {
+		c.Host = cfg.Host
+	}
+	if c.ClientID == "" {
+		c.ClientID = defaultClientID
+	}
+	if c.RedirectURI == "" {
+		c.RedirectURI = defaultRedirectURI
+	}
+
+	fmt.Printf("External browser authentication completed successfully.\n")
+	return c.createCredentialsProvider(), nil
+}
+
+// creates a CredentialsProvider that uses our access token
+func (c *ExternalBrowserCredentials) createCredentialsProvider() credentials.CredentialsProvider {
+	// Create a TokenSource that returns our OAuth token
+	tokenSource := auth.TokenSourceFn(func(ctx context.Context) (*oauth2.Token, error) {
+		fmt.Printf("Starting OAuth flow for external browser authentication...\n")
+		return c.performOAuthFlow(ctx)
+	})
+
+	cachedTokenSource := auth.NewCachedTokenSource(tokenSource)
+	return credentials.NewOAuthCredentialsProviderFromTokenSource(cachedTokenSource)
+}
+
+// builds the token endpoint URL with proper protocol scheme
+func (c *ExternalBrowserCredentials) buildTokenURL() string {
+	host := c.Host
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = "https://" + host
+	}
+	return strings.TrimSuffix(host, "/") + "/" + tokenPath
+}
+
+// performs full OAuth PKCE flow
+func (c *ExternalBrowserCredentials) performOAuthFlow(ctx context.Context) (*oauth2.Token, error) {
+	// PKCE verifier
+	verifier := oauth2.GenerateVerifier()
+
+	// State for CSRF protection
+	state := oauth2.GenerateVerifier()
+
+	// Find available port
+	port := c.findAvailablePort()
+	redirectURI := fmt.Sprintf("http://localhost:%d", port)
+
+	config := &oauth2.Config{
+		ClientID: c.ClientID,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  c.buildAuthBaseURL(),
+			TokenURL: c.buildTokenURL(),
+		},
+		RedirectURL: redirectURI,
+		Scopes:      []string{"all-apis", "offline_access"},
+	}
+
+	authURL := config.AuthCodeURL(state,
+		oauth2.S256ChallengeOption(verifier),
+		oauth2.AccessTypeOffline)
+
+	codeChan := make(chan string, 1)
+	errorChan := make(chan error, 1)
+
+	// local server to receive auth code from redirect
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%d", port),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			code := r.URL.Query().Get("code")
+			errorParam := r.URL.Query().Get("error")
+
+			if errorParam != "" {
+				errorDesc := r.URL.Query().Get("error_description")
+				fmt.Fprintf(w, browserErrorWithDescHtml, errorParam, errorDesc)
+				errorChan <- fmt.Errorf("oauth error: %s - %s", errorParam, errorDesc)
+				return
+			}
+
+			if code == "" {
+				fmt.Fprint(w, browserErrorGenericHtml)
+				errorChan <- fmt.Errorf("no authorization code received")
+				return
+			}
+
+			// Verify state parameter matches to prevent CSRF attacks
+			if r.URL.Query().Get("state") != state {
+				fmt.Fprintf(w, browserErrorWithDescHtml, "state mismatch", "state parameter did not match. Possible CSRF attack.")
+				errorChan <- fmt.Errorf("state mismatch - possible CSRF attack")
+				return
+			}
+
+			fmt.Fprint(w, browserSuccessHtml)
+			codeChan <- code
+		}),
+	}
+
+	// start local server
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errorChan <- fmt.Errorf("server error: %w", err)
+		}
+	}()
+
+	// wait for server to start up
+	time.Sleep(100 * time.Millisecond)
+
+	if err := openBrowser(ctx, authURL); err != nil {
+		return nil, err
+	}
+
+	// Wait for authorization code or 10 min timeout
+	var authCode string
+	select {
+	case authCode = <-codeChan:
+		fmt.Printf("Authorization code received successfully.\n")
+	case err := <-errorChan:
+		server.Shutdown(ctx)
+		return nil, fmt.Errorf("oauth callback error: %w", err)
+	case <-time.After(10 * time.Minute):
+		server.Shutdown(ctx)
+		return nil, fmt.Errorf("authentication timeout after 10 minutes - please ensure you complete the browser authentication flow")
+	case <-ctx.Done():
+		server.Shutdown(ctx)
+		return nil, fmt.Errorf("authentication cancelled: %w", ctx.Err())
+	}
+
+	// Shutdown server
+	server.Shutdown(ctx)
+
+	// Exchange code for tokens
+	return c.exchangeCodeForTokens(ctx, authCode, verifier, redirectURI)
+}
+
+// findAvailablePort finds an available port starting from the default
+func (c *ExternalBrowserCredentials) findAvailablePort() int {
+	// Try the default port first
+	if c.isPortAvailable(defaultPort) {
+		return defaultPort
+	}
+
+	// Try ports in a reasonable range
+	for port := defaultPort + 1; port < defaultPort+100; port++ {
+		if c.isPortAvailable(port) {
+			fmt.Printf("Port %d was in use, using port %d instead.\n", defaultPort, port)
+			return port
+		}
+	}
+
+	// If we can't find any available port, return the default and let it fail with a clear error
+	fmt.Printf("Warning: Could not find an available port, using default port %d.\n", defaultPort)
+	return defaultPort
+}
+
+// isPortAvailable checks if a port is available
+func (c *ExternalBrowserCredentials) isPortAvailable(port int) bool {
+	addr := fmt.Sprintf(":%d", port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return false
+	}
+	ln.Close()
+	return true
+}
+
+// base oidc endpoint
+func (c *ExternalBrowserCredentials) buildAuthBaseURL() string {
+	host := c.Host
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = "https://" + host
+	}
+	return strings.TrimSuffix(host, "/") + "/" + authorizePath
+}
+
+// exchangeCodeForTokens exchanges the authorization code for access/refresh tokens
+func (c *ExternalBrowserCredentials) exchangeCodeForTokens(ctx context.Context, code, codeVerifier, redirectURI string) (*oauth2.Token, error) {
+	config := &oauth2.Config{
+		ClientID: c.ClientID,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: c.buildTokenURL(),
+		},
+		RedirectURL: redirectURI,
+		Scopes:      []string{"all-apis", "offline_access"},
+	}
+
+	// exchange for token with PKCE
+	return config.Exchange(ctx, code,
+		oauth2.SetAuthURLParam("code_verifier", codeVerifier),
+		oauth2.S256ChallengeOption(oauth2.GenerateVerifier()),
+	)
+}
+
+// will fail if no display (headless shell)
+func openBrowser(ctx context.Context, browserURL string) error {
+	parsedURL, err := url.ParseRequestURI(browserURL)
+	if err != nil {
+		logger.Errorf(ctx, "error parsing url %v, err: %v", browserURL, err)
+		return err
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("invalid browser URL: %v", browserURL)
+	}
+	err = browser.OpenURL(browserURL)
+	if err != nil {
+		logger.Errorf(ctx, "failed to open a browser. err: %v", err)
+		return err
+	}
+	return nil
+}

--- a/go/adbc/driver/databricks/external_browser_credentials.go
+++ b/go/adbc/driver/databricks/external_browser_credentials.go
@@ -334,11 +334,10 @@ func (c *ExternalBrowserCredentials) findAvailablePort() int {
 func (c *ExternalBrowserCredentials) isPortAvailable(port int) bool {
 	addr := fmt.Sprintf(":%d", port)
 	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return false
+	if err == nil {
+		ln.Close()
 	}
-	ln.Close()
-	return true
+	return err != nil
 }
 
 // base oidc endpoint

--- a/go/adbc/driver/databricks/external_browser_credentials.go
+++ b/go/adbc/driver/databricks/external_browser_credentials.go
@@ -81,6 +81,7 @@ const (
 )
 
 // ExternalBrowserCredentials implements CredentialsStrategy for OAuth 2 PKCE flow for external browser authentication
+// https://github.com/databricks/databricks-sdk-go/blob/56af964ae7d5f86bd454dfdba4edac42aac4d19f/config/config.go#L26
 // TODO(jasonlin45): add os/fs based caching for multi-driver concurrency scenarios and session persistence
 type ExternalBrowserCredentials struct {
 	Host        string
@@ -111,9 +112,9 @@ func (c *ExternalBrowserCredentials) Configure(ctx context.Context, cfg *config.
 
 // creates a CredentialsProvider that uses our access token
 func (c *ExternalBrowserCredentials) createCredentialsProvider() credentials.CredentialsProvider {
-	// Create a TokenSource that returns our OAuth token
+	// TokenSourceFn wraps a token fetching function to be invoked for getting new tokens
 	tokenSource := auth.TokenSourceFn(func(ctx context.Context) (*oauth2.Token, error) {
-		fmt.Printf("Starting OAuth flow for external browser authentication...\n")
+		// TODO(jasonlin45): handle refresh token here
 		return c.performOAuthFlow(ctx)
 	})
 
@@ -131,6 +132,8 @@ func (c *ExternalBrowserCredentials) buildTokenURL() string {
 }
 
 // performs full OAuth PKCE flow
+// OAuth2: RFC9470
+// PKCE: RFC7636
 func (c *ExternalBrowserCredentials) performOAuthFlow(ctx context.Context) (*oauth2.Token, error) {
 	// PKCE verifier
 	verifier := oauth2.GenerateVerifier()
@@ -209,7 +212,6 @@ func (c *ExternalBrowserCredentials) performOAuthFlow(ctx context.Context) (*oau
 	var authCode string
 	select {
 	case authCode = <-codeChan:
-		fmt.Printf("Authorization code received successfully.\n")
 	case err := <-errorChan:
 		server.Shutdown(ctx)
 		return nil, fmt.Errorf("oauth callback error: %w", err)

--- a/go/adbc/driver/databricks/token_cache.go
+++ b/go/adbc/driver/databricks/token_cache.go
@@ -1,0 +1,395 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package databricks
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/oauth2"
+)
+
+const (
+	cacheLeaseTimeout  = 30 * time.Second
+	leaseRenewInterval = 10 * time.Second
+	// owner rw
+	cacheFilePermission = 0600
+	// owner rwx
+	cacheDirPermission = 0700
+)
+
+// LeaseInfo contains lease metadata with UUID-based identification
+type LeaseInfo struct {
+	LeaseID      string `json:"lease_id"`
+	DeadlineUnix int64  `json:"deadline_unix"`
+}
+
+type TokenCacheEntry struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenType    string    `json:"token_type"`
+	Expiry       time.Time `json:"expiry"`
+	Host         string    `json:"host"`
+	ClientID     string    `json:"client_id"`
+}
+
+func (e *TokenCacheEntry) ToToken() *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  e.AccessToken,
+		RefreshToken: e.RefreshToken,
+		TokenType:    e.TokenType,
+		Expiry:       e.Expiry,
+	}
+}
+
+// TokenCache handles caching of OAuth tokens using a lease
+type TokenCache struct {
+	cacheDir string
+	leaseID  string
+}
+
+func NewTokenCache() (*TokenCache, error) {
+	cacheDir, err := getCacheDirectory()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cache directory: %w", err)
+	}
+
+	// Ensure cache directory exists with proper permissions
+	if err := os.MkdirAll(cacheDir, cacheDirPermission); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	return &TokenCache{
+		cacheDir: cacheDir,
+	}, nil
+}
+
+func getCacheDirectory() (string, error) {
+	var cacheDir string
+
+	switch runtime.GOOS {
+	case "windows":
+		// Windows: %APPDATA%\databricks-adbc
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("failed to get user home directory: %w", err)
+			}
+			appData = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+		cacheDir = filepath.Join(appData, "databricks-adbc")
+
+	case "darwin":
+		// macOS: ~/Library/Caches/databricks-adbc
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		cacheDir = filepath.Join(homeDir, "Library", "Caches", "databricks-adbc")
+
+	default:
+		// Linux and other Unix-like systems: ~/.cache/databricks-adbc or $XDG_CACHE_HOME/databricks-adbc
+		xdgCache := os.Getenv("XDG_CACHE_HOME")
+		if xdgCache != "" {
+			cacheDir = filepath.Join(xdgCache, "databricks-adbc")
+		} else {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("failed to get user home directory: %w", err)
+			}
+			cacheDir = filepath.Join(homeDir, ".cache", "databricks-adbc")
+		}
+	}
+
+	return cacheDir, nil
+}
+
+func (tc *TokenCache) getCacheKey(host, clientID string) string {
+	// Create a hash of host+clientID to ensure unique cache entries
+	hash := sha256.Sum256([]byte(host + ":" + clientID))
+	return fmt.Sprintf("token_%x.json", hash[:8])
+}
+
+func (tc *TokenCache) getFilePaths(host, clientID string) (string, string) {
+	cacheKey := tc.getCacheKey(host, clientID)
+	cacheFile := filepath.Join(tc.cacheDir, cacheKey)
+	leaseFile := cacheFile + ".lease"
+	return cacheFile, leaseFile
+}
+
+// acquireLease attempts to acquire a lease using UUID-based approach
+func (tc *TokenCache) acquireLease(ctx context.Context, leaseFile string) error {
+	// Generate UUID for this lease attempt
+	leaseID := uuid.New().String()
+
+	for {
+		deadline := time.Now().Add(cacheLeaseTimeout)
+
+		// Try to open lease file (create if doesn't exist)
+		file, err := os.OpenFile(leaseFile, os.O_CREATE|os.O_RDWR, cacheFilePermission)
+		if err != nil {
+			return fmt.Errorf("failed to open lease file: %w", err)
+		}
+
+		// Read existing lease info if present
+		data, readErr := os.ReadFile(leaseFile)
+		var existingLease LeaseInfo
+
+		if readErr == nil && len(data) > 0 {
+			json.Unmarshal(data, &existingLease)
+		}
+
+		// Check if deadline has passed
+		now := time.Now()
+		existingDeadline := time.Unix(existingLease.DeadlineUnix, 0)
+
+		if existingLease.LeaseID == "" || now.After(existingDeadline) {
+			// Lease is available - acquire it
+			newLease := LeaseInfo{
+				LeaseID:      leaseID,
+				DeadlineUnix: deadline.Unix(),
+			}
+
+			leaseData, _ := json.Marshal(newLease)
+
+			// Truncate and write new lease
+			file.Truncate(0)
+			file.Seek(0, 0)
+			file.Write(leaseData)
+			file.Close()
+
+			tc.leaseID = leaseID
+			return nil
+		} else {
+			// Lease is held by another process - sleep until deadline and retry
+			file.Close()
+
+			sleepDuration := time.Until(existingDeadline)
+			if sleepDuration > 0 {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(sleepDuration):
+					// Continue to retry
+				}
+			}
+		}
+	}
+}
+
+// renewLease extends the lease deadline for the current lease ID
+func (tc *TokenCache) renewLease(leaseFile string) error {
+	if tc.leaseID == "" {
+		return fmt.Errorf("no active lease to renew")
+	}
+
+	// Open lease file
+	file, err := os.OpenFile(leaseFile, os.O_RDWR, cacheFilePermission)
+	if err != nil {
+		return fmt.Errorf("failed to open lease file for renewal: %w", err)
+	}
+	defer file.Close()
+
+	// Read current lease
+	data, err := os.ReadFile(leaseFile)
+	if err != nil {
+		return fmt.Errorf("failed to read lease file: %w", err)
+	}
+
+	var currentLease LeaseInfo
+	if err := json.Unmarshal(data, &currentLease); err != nil {
+		return fmt.Errorf("failed to parse lease file: %w", err)
+	}
+
+	// Check if we still own the lease and it's not expired
+	now := time.Now()
+	deadline := time.Unix(currentLease.DeadlineUnix, 0)
+
+	if currentLease.LeaseID == tc.leaseID && now.Before(deadline) {
+		// Renew the lease
+		currentLease.DeadlineUnix = now.Add(cacheLeaseTimeout).Unix()
+
+		renewedData, _ := json.Marshal(currentLease)
+
+		// Truncate and write renewed lease
+		file.Truncate(0)
+		file.Seek(0, 0)
+		file.Write(renewedData)
+
+		return nil
+	} else {
+		// We no longer own the lease or it expired
+		return fmt.Errorf("lease no longer owned or expired")
+	}
+}
+
+// releaseLease removes the lease file completely
+func (tc *TokenCache) releaseLease(leaseFile string) {
+	if tc.leaseID == "" {
+		return
+	}
+
+	os.Remove(leaseFile)
+	tc.leaseID = ""
+}
+
+// LoadToken attempts to load a cached token
+func (tc *TokenCache) LoadToken(ctx context.Context, host, clientID string) (*TokenCacheEntry, error) {
+	cacheFile, leaseFile := tc.getFilePaths(host, clientID)
+
+	// Acquire lease
+	if err := tc.acquireLease(ctx, leaseFile); err != nil {
+		return nil, fmt.Errorf("failed to acquire cache lease: %w", err)
+	}
+	defer tc.releaseLease(leaseFile)
+
+	// Renew lease before file operations
+	tc.renewLease(leaseFile)
+
+	// Check if cache file exists
+	if _, err := os.Stat(cacheFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("no cached token found")
+	}
+
+	// Read and parse cache file
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cache file: %w", err)
+	}
+
+	// Renew lease during parsing
+	tc.renewLease(leaseFile)
+
+	var entry TokenCacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("failed to parse cached token: %w", err)
+	}
+
+	// Verify token is for the correct host and client
+	if entry.Host != host || entry.ClientID != clientID {
+		return nil, fmt.Errorf("cached token is for different host/client")
+	}
+
+	// Return the cache entry for caller to handle
+	return &entry, nil
+}
+
+// SaveToken saves a token to the cache
+func (tc *TokenCache) SaveToken(ctx context.Context, token *oauth2.Token, host, clientID string) error {
+	if token == nil {
+		return fmt.Errorf("token cannot be nil")
+	}
+
+	cacheFile, leaseFile := tc.getFilePaths(host, clientID)
+
+	// Acquire lease
+	if err := tc.acquireLease(ctx, leaseFile); err != nil {
+		return fmt.Errorf("failed to acquire cache lease: %w", err)
+	}
+	defer tc.releaseLease(leaseFile)
+
+	// Renew lease before operations
+	tc.renewLease(leaseFile)
+
+	// Create cache entry
+	entry := TokenCacheEntry{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.TokenType,
+		Expiry:       token.Expiry,
+		Host:         host,
+		ClientID:     clientID,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token cache entry: %w", err)
+	}
+
+	// Renew lease before file write
+	tc.renewLease(leaseFile)
+
+	// Write to temporary file first, then rename for atomic operation
+	tempFile := cacheFile + ".tmp"
+	if err := os.WriteFile(tempFile, data, cacheFilePermission); err != nil {
+		return fmt.Errorf("failed to write temporary cache file: %w", err)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tempFile, cacheFile); err != nil {
+		os.Remove(tempFile) // Clean up temp file on failure
+		return fmt.Errorf("failed to rename cache file: %w", err)
+	}
+
+	return nil
+}
+
+// ClearExpiredTokens removes expired tokens from the cache
+func (tc *TokenCache) ClearExpiredTokens(ctx context.Context) error {
+	entries, err := os.ReadDir(tc.cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to read cache directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		filePath := filepath.Join(tc.cacheDir, entry.Name())
+
+		// Handle .json cache files
+		if strings.HasSuffix(entry.Name(), ".json") {
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				continue
+			}
+
+			var cacheEntry TokenCacheEntry
+			if err := json.Unmarshal(data, &cacheEntry); err != nil {
+				continue
+			}
+
+			// Remove expired tokens and their corresponding lease files
+			if time.Now().After(cacheEntry.Expiry) {
+				os.Remove(filePath)
+				os.Remove(filePath + ".lease")
+			}
+		}
+
+		// Handle orphaned .lease files (lease files without corresponding .json files)
+		if strings.HasSuffix(entry.Name(), ".lease") {
+			jsonFile := strings.TrimSuffix(filePath, ".lease")
+			if _, err := os.Stat(jsonFile); os.IsNotExist(err) {
+				os.Remove(filePath)
+			}
+		}
+	}
+
+	return nil
+}

--- a/go/adbc/driver/databricks/token_cache_test.go
+++ b/go/adbc/driver/databricks/token_cache_test.go
@@ -1,0 +1,686 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package databricks
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestTokenCache_SaveAndLoad(t *testing.T) {
+	// Create a temporary cache directory for testing
+	tempDir, err := os.MkdirTemp("", "adbc-token-cache-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create token cache with custom directory
+	cache := &TokenCache{cacheDir: tempDir}
+
+	ctx := context.Background()
+	host := "test-workspace.cloud.databricks.com"
+	clientID := "test-client-id"
+
+	// Create a test token
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "test-refresh-token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	// Save token to cache
+	err = cache.SaveToken(ctx, token, host, clientID)
+	require.NoError(t, err)
+
+	// Load token from cache
+	loadedEntry, err := cache.LoadToken(ctx, host, clientID)
+	require.NoError(t, err)
+
+	// Verify token data
+	assert.Equal(t, token.AccessToken, loadedEntry.AccessToken)
+	assert.Equal(t, token.RefreshToken, loadedEntry.RefreshToken)
+	assert.Equal(t, token.TokenType, loadedEntry.TokenType)
+	assert.WithinDuration(t, token.Expiry, loadedEntry.Expiry, time.Second)
+}
+
+func TestTokenCache_ExpiredToken(t *testing.T) {
+	// Create a temporary cache directory for testing
+	tempDir, err := os.MkdirTemp("", "adbc-token-cache-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create token cache with custom directory
+	cache := &TokenCache{cacheDir: tempDir}
+
+	ctx := context.Background()
+	host := "test-workspace.cloud.databricks.com"
+	clientID := "test-client-id"
+
+	// Create an expired token
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "test-refresh-token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-1 * time.Hour), // Expired 1 hour ago
+	}
+
+	// Save token to cache
+	err = cache.SaveToken(ctx, token, host, clientID)
+	require.NoError(t, err)
+
+	// Try to load expired token - should succeed but caller handles expiration
+	loadedEntry, err := cache.LoadToken(ctx, host, clientID)
+	require.NoError(t, err)
+
+	// Verify the token is expired (caller's responsibility to check)
+	assert.True(t, time.Now().After(loadedEntry.Expiry))
+	assert.Equal(t, "test-access-token", loadedEntry.AccessToken)
+}
+
+func TestTokenCache_ConcurrentAccess(t *testing.T) {
+	// Test concurrent access to the same cache entry
+	tempDir := t.TempDir()
+
+	const numGoroutines = 5 // Reduced for faster testing
+	const host = "test-host.databricks.com"
+	const clientID = "test-client-id"
+
+	results := make(chan error, numGoroutines)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			// Add small jitter to reduce thundering herd
+			time.Sleep(time.Duration(id*50) * time.Millisecond)
+
+			cache := &TokenCache{cacheDir: tempDir}
+
+			// Use longer timeout that accounts for potential lease waiting
+			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+
+			token := &oauth2.Token{
+				AccessToken:  "access-token-" + string(rune(id)),
+				RefreshToken: "refresh-token-" + string(rune(id)),
+				TokenType:    "Bearer",
+				Expiry:       time.Now().Add(time.Hour),
+			}
+
+			err := cache.SaveToken(ctx, token, host, clientID)
+			results <- err
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Check that all operations completed successfully
+	successCount := 0
+	for err := range results {
+		if err == nil {
+			successCount++
+		} else {
+			t.Logf("Goroutine failed: %v", err)
+		}
+	}
+
+	// Most operations should succeed (allowing for some timeouts under extreme load)
+	if successCount < numGoroutines/2 {
+		t.Fatalf("Too few operations succeeded: %d/%d", successCount, numGoroutines)
+	}
+
+	t.Logf("Concurrent access test: %d/%d operations succeeded", successCount, numGoroutines)
+}
+
+func TestTokenCache_DifferentHosts(t *testing.T) {
+	// Create a temporary cache directory for testing
+	tempDir, err := os.MkdirTemp("", "adbc-token-cache-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create token cache with custom directory
+	cache := &TokenCache{cacheDir: tempDir}
+
+	ctx := context.Background()
+	host1 := "workspace1.cloud.databricks.com"
+	host2 := "workspace2.cloud.databricks.com"
+	clientID := "test-client-id"
+
+	// Create tokens for different hosts
+	token1 := &oauth2.Token{
+		AccessToken:  "token-for-host1",
+		RefreshToken: "refresh-for-host1",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	token2 := &oauth2.Token{
+		AccessToken:  "token-for-host2",
+		RefreshToken: "refresh-for-host2",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	// Save tokens for different hosts
+	err = cache.SaveToken(ctx, token1, host1, clientID)
+	require.NoError(t, err)
+
+	err = cache.SaveToken(ctx, token2, host2, clientID)
+	require.NoError(t, err)
+
+	// Load and verify tokens are separate
+	loadedEntry1, err := cache.LoadToken(ctx, host1, clientID)
+	require.NoError(t, err)
+	assert.Equal(t, "token-for-host1", loadedEntry1.AccessToken)
+
+	loadedEntry2, err := cache.LoadToken(ctx, host2, clientID)
+	require.NoError(t, err)
+	assert.Equal(t, "token-for-host2", loadedEntry2.AccessToken)
+}
+
+func TestTokenCache_GetCacheDirectory(t *testing.T) {
+	cacheDir, err := getCacheDirectory()
+	require.NoError(t, err)
+	assert.NotEmpty(t, cacheDir)
+
+	// Verify it contains our app name
+	assert.Contains(t, cacheDir, "databricks-adbc")
+
+	// Verify it's an absolute path
+	assert.True(t, filepath.IsAbs(cacheDir))
+}
+
+func TestTokenCache_LeaseSystem(t *testing.T) {
+	// Create a temporary cache directory for testing
+	tempDir, err := os.MkdirTemp("", "adbc-token-cache-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	cache1 := &TokenCache{cacheDir: tempDir}
+	cache2 := &TokenCache{cacheDir: tempDir}
+	ctx := context.Background()
+
+	// Test lease acquisition
+	leaseFile := filepath.Join(tempDir, "test.lease")
+
+	// First acquisition should succeed
+	err = cache1.acquireLease(ctx, leaseFile)
+	assert.NoError(t, err)
+
+	// Second acquisition should timeout (lease already held)
+	ctx2, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err = cache2.acquireLease(ctx2, leaseFile)
+	assert.Error(t, err)
+	assert.True(t, err == context.DeadlineExceeded || err == context.Canceled)
+
+	// Release lease
+	cache1.releaseLease(leaseFile)
+
+	// Should be able to acquire again after release
+	err = cache2.acquireLease(ctx, leaseFile)
+	assert.NoError(t, err)
+
+	// Clean up
+	cache2.releaseLease(leaseFile)
+}
+
+func TestTokenCache_LeaseWaitingAndRetry(t *testing.T) {
+	tempDir := t.TempDir()
+	cache1 := &TokenCache{cacheDir: tempDir}
+	cache2 := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache1.getFilePaths(host, clientID)
+
+	ctx := context.Background()
+
+	// Cache1 acquires lease
+	err := cache1.acquireLease(ctx, leaseFile)
+	require.NoError(t, err)
+
+	// Start goroutine that will release lease after short delay
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cache1.releaseLease(leaseFile)
+	}()
+
+	// Cache2 should wait and then successfully acquire
+	start := time.Now()
+	err = cache2.acquireLease(ctx, leaseFile)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.True(t, elapsed >= 400*time.Millisecond, "Should have waited for lease to be released")
+
+	cache2.releaseLease(leaseFile)
+}
+
+func TestTokenCache_ContextCancellation(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	// Create a lease file that won't expire for a while
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	lease := LeaseInfo{
+		LeaseID:      uuid.New().String(),
+		DeadlineUnix: time.Now().Add(time.Hour).Unix(),
+	}
+	leaseData, _ := json.Marshal(lease)
+	os.WriteFile(leaseFile, leaseData, 0600)
+
+	// Try to acquire lease with short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := cache.acquireLease(ctx, leaseFile)
+	if err != context.DeadlineExceeded && err != context.Canceled {
+		t.Errorf("Expected context cancellation error, got: %v", err)
+	}
+}
+
+func TestTokenCache_CorruptedLeaseFile(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	// Write corrupted JSON to lease file
+	os.WriteFile(leaseFile, []byte("invalid json{"), 0600)
+
+	ctx := context.Background()
+
+	// Should be able to acquire lease despite corruption
+	err := cache.acquireLease(ctx, leaseFile)
+	if err != nil {
+		t.Errorf("Should handle corrupted lease file gracefully, got: %v", err)
+	}
+
+	// Verify lease was acquired
+	if cache.leaseID == "" {
+		t.Error("Lease ID should be set after acquiring lease")
+	}
+}
+
+func TestTokenCache_EmptyLeaseFile(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	// Create empty lease file
+	os.WriteFile(leaseFile, []byte(""), 0600)
+
+	ctx := context.Background()
+
+	// Should be able to acquire lease from empty file
+	err := cache.acquireLease(ctx, leaseFile)
+	if err != nil {
+		t.Errorf("Should handle empty lease file gracefully, got: %v", err)
+	}
+
+	if cache.leaseID == "" {
+		t.Error("Lease ID should be set after acquiring lease")
+	}
+}
+
+func TestTokenCache_LeaseRenewal(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	ctx := context.Background()
+
+	// Acquire lease
+	err := cache.acquireLease(ctx, leaseFile)
+	if err != nil {
+		t.Fatalf("Failed to acquire lease: %v", err)
+	}
+
+	originalLeaseID := cache.leaseID
+
+	// Wait a bit and renew
+	time.Sleep(100 * time.Millisecond)
+	err = cache.renewLease(leaseFile)
+	if err != nil {
+		t.Errorf("Failed to renew lease: %v", err)
+	}
+
+	// Lease ID should remain the same
+	if cache.leaseID != originalLeaseID {
+		t.Error("Lease ID changed during renewal")
+	}
+
+	// Verify deadline was updated
+	data, _ := os.ReadFile(leaseFile)
+	var renewed LeaseInfo
+	json.Unmarshal(data, &renewed)
+
+	if renewed.LeaseID != originalLeaseID {
+		t.Error("Lease ID in file doesn't match")
+	}
+
+	if time.Unix(renewed.DeadlineUnix, 0).Before(time.Now().Add(25 * time.Second)) {
+		t.Error("Lease deadline wasn't properly renewed")
+	}
+}
+
+func TestTokenCache_LeaseRenewalWithoutOwnership(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	// Create a lease owned by another process
+	otherLease := LeaseInfo{
+		LeaseID:      uuid.New().String(),
+		DeadlineUnix: time.Now().Add(time.Hour).Unix(),
+	}
+	leaseData, _ := json.Marshal(otherLease)
+	os.WriteFile(leaseFile, leaseData, 0600)
+
+	// Try to renew without owning the lease
+	err := cache.renewLease(leaseFile)
+	if err == nil {
+		t.Error("Should not be able to renew lease we don't own")
+	}
+}
+
+func TestTokenCache_ExpiredTokenHandling(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+
+	// Save an expired token
+	expiredToken := &oauth2.Token{
+		AccessToken:  "expired-token",
+		RefreshToken: "refresh-token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Hour), // Expired 1 hour ago
+	}
+
+	ctx := context.Background()
+	err := cache.SaveToken(ctx, expiredToken, host, clientID)
+	if err != nil {
+		t.Fatalf("Failed to save expired token: %v", err)
+	}
+
+	// Try to load expired token - should succeed but caller handles expiration
+	loadedEntry, err := cache.LoadToken(ctx, host, clientID)
+	require.NoError(t, err)
+
+	// Verify the token is expired (caller's responsibility to check)
+	assert.True(t, time.Now().After(loadedEntry.Expiry))
+	assert.Equal(t, "expired-token", loadedEntry.AccessToken)
+}
+
+func TestTokenCache_FileSystemErrors(t *testing.T) {
+	// Test with read-only directory
+	tempDir := t.TempDir()
+	readOnlyDir := filepath.Join(tempDir, "readonly")
+	os.Mkdir(readOnlyDir, 0444) // Read-only
+
+	cache := &TokenCache{cacheDir: readOnlyDir}
+
+	token := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+
+	ctx := context.Background()
+	err := cache.SaveToken(ctx, token, "host", "client")
+	if err == nil {
+		t.Error("Should fail when trying to write to read-only directory")
+	}
+}
+
+func TestTokenCache_ReleaseLease(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	ctx := context.Background()
+
+	// Acquire lease
+	err := cache.acquireLease(ctx, leaseFile)
+	if err != nil {
+		t.Fatalf("Failed to acquire lease: %v", err)
+	}
+
+	// Verify lease file exists and has content
+	data, err := os.ReadFile(leaseFile)
+	if err != nil || len(data) == 0 {
+		t.Error("Lease file should exist and have content")
+	}
+
+	// Release lease
+	cache.releaseLease(leaseFile)
+
+	// Verify lease ID is cleared
+	if cache.leaseID != "" {
+		t.Error("Lease ID should be cleared after release")
+	}
+
+	// Verify lease file is deleted
+	_, err = os.Stat(leaseFile)
+	if !os.IsNotExist(err) {
+		t.Error("Lease file should be deleted after release")
+	}
+}
+
+func TestTokenCache_TokenValidation(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	ctx := context.Background()
+
+	// Test saving nil token
+	err := cache.SaveToken(ctx, nil, "host", "client")
+	if err == nil {
+		t.Error("Should reject nil token")
+	}
+
+	// Test token with wrong host/client
+	token := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+
+	err = cache.SaveToken(ctx, token, "host1", "client1")
+	if err != nil {
+		t.Fatalf("Failed to save token: %v", err)
+	}
+
+	// Try to load with different host/client
+	_, err = cache.LoadToken(ctx, "host2", "client2")
+	if err == nil {
+		t.Error("Should not load token for different host/client")
+	}
+}
+
+func TestTokenCache_ClearExpiredTokens(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	ctx := context.Background()
+
+	// Save valid token
+	validToken := &oauth2.Token{
+		AccessToken: "valid-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	cache.SaveToken(ctx, validToken, "host1", "client1")
+
+	// Save expired token
+	expiredToken := &oauth2.Token{
+		AccessToken: "expired-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(-time.Hour),
+	}
+	cache.SaveToken(ctx, expiredToken, "host2", "client2")
+
+	// Clear expired tokens
+	err := cache.ClearExpiredTokens(ctx)
+	if err != nil {
+		t.Errorf("Failed to clear expired tokens: %v", err)
+	}
+
+	// Valid token should still be loadable
+	_, err = cache.LoadToken(ctx, "host1", "client1")
+	if err != nil {
+		t.Error("Valid token should still be loadable after cleanup")
+	}
+
+	// Expired token should be gone (though it would fail to load anyway due to expiration check)
+	files, _ := os.ReadDir(tempDir)
+	jsonFiles := 0
+	for _, file := range files {
+		if filepath.Ext(file.Name()) == ".json" {
+			jsonFiles++
+		}
+	}
+
+	if jsonFiles != 1 {
+		t.Errorf("Expected 1 JSON file after cleanup, found %d", jsonFiles)
+	}
+}
+
+func TestTokenCache_LongRunningOperation(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	host := "test-host.databricks.com"
+	clientID := "test-client-id"
+	_, leaseFile := cache.getFilePaths(host, clientID)
+
+	ctx := context.Background()
+
+	// Acquire lease
+	err := cache.acquireLease(ctx, leaseFile)
+	if err != nil {
+		t.Fatalf("Failed to acquire lease: %v", err)
+	}
+
+	// Simulate long operation with periodic renewals
+	for i := 0; i < 5; i++ {
+		time.Sleep(100 * time.Millisecond)
+		err = cache.renewLease(leaseFile)
+		if err != nil {
+			t.Errorf("Failed to renew lease during long operation (iteration %d): %v", i, err)
+		}
+	}
+
+	cache.releaseLease(leaseFile)
+}
+
+func TestTokenCache_MissingCacheFile(t *testing.T) {
+	tempDir := t.TempDir()
+	cache := &TokenCache{cacheDir: tempDir}
+
+	ctx := context.Background()
+
+	// Try to load token from non-existent cache
+	_, err := cache.LoadToken(ctx, "host", "client")
+	if err == nil {
+		t.Error("Should fail when cache file doesn't exist")
+	}
+}
+
+func TestTokenCacheEntry_ToToken(t *testing.T) {
+	entry := &TokenCacheEntry{
+		AccessToken:  "test-access-token",
+		RefreshToken: "test-refresh-token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+		Host:         "test-host",
+		ClientID:     "test-client",
+	}
+
+	token := entry.ToToken()
+
+	// Verify all fields are correctly copied
+	assert.Equal(t, entry.AccessToken, token.AccessToken)
+	assert.Equal(t, entry.RefreshToken, token.RefreshToken)
+	assert.Equal(t, entry.TokenType, token.TokenType)
+	assert.Equal(t, entry.Expiry, token.Expiry)
+
+	// Verify it returns a proper oauth2.Token
+	assert.IsType(t, &oauth2.Token{}, token)
+}
+
+// Benchmark concurrent access performance
+func BenchmarkTokenCache_ConcurrentAccess(b *testing.B) {
+	tempDir := b.TempDir()
+
+	const numGoroutines = 100
+	host := "benchmark-host.databricks.com"
+	clientID := "benchmark-client-id"
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			cache := &TokenCache{cacheDir: tempDir}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+			token := &oauth2.Token{
+				AccessToken:  "benchmark-token",
+				RefreshToken: "benchmark-refresh",
+				TokenType:    "Bearer",
+				Expiry:       time.Now().Add(time.Hour),
+			}
+
+			cache.SaveToken(ctx, token, host, clientID)
+			cancel()
+		}
+	})
+}

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -25,7 +25,7 @@ require (
 	cloud.google.com/go/bigquery v1.67.0
 	github.com/apache/arrow-go/v18 v18.2.0
 	github.com/bluele/gcache v0.0.2
-	github.com/databricks/databricks-sdk-go v0.62.0
+	github.com/databricks/databricks-sdk-go v0.72.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/snowflakedb/gosnowflake v1.14.1
@@ -38,6 +38,7 @@ require (
 	google.golang.org/api v0.230.0
 	google.golang.org/grpc v1.72.0
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/ini.v1 v1.67.0
 	modernc.org/sqlite v1.37.0
 )
 
@@ -121,7 +122,6 @@ require (
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.62.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -98,8 +98,8 @@ github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 h1:Om6kYQYDUk5wWbT0t0q
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
-github.com/databricks/databricks-sdk-go v0.62.0 h1:z4fpPXSHHmXESJVu2CqCxa0UMWkpDxGR5t9FZKOVkiA=
-github.com/databricks/databricks-sdk-go v0.62.0/go.mod h1:xBtjeP9nq+6MgTewZW1EcbRkD7aDY9gZvcRPcwPhZjw=
+github.com/databricks/databricks-sdk-go v0.72.0 h1:vNS4zlpvNYiXsy/7/lzV7cuu/yOcT/1xpfuJw3+W3TA=
+github.com/databricks/databricks-sdk-go v0.72.0/go.mod h1:xBtjeP9nq+6MgTewZW1EcbRkD7aDY9gZvcRPcwPhZjw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
addresses https://github.com/dbt-labs/fs/issues/3915

# Summary
This adds 3 legged OAuth2 via a local redirect server when auth type is specified as `external-browser`

The Databricks Go SDK currently does not support this auth type, whereas the Python one does. This discrepancy is causing issues when users attempt to use OAuth U2M (no client secret provided).

# Demo
## Before
![image](https://github.com/user-attachments/assets/df245080-e799-462c-a76a-6cc5fbf547f6)

## After


https://github.com/user-attachments/assets/9152b1f9-59e9-4de2-904f-456f73f93296


