### PR TITLE
feat(go/adbc/driver/databricks) Schema Parser

### DIFF
--- a/go/adbc/driver/databricks/schema.go
+++ b/go/adbc/driver/databricks/schema.go
@@ -235,6 +235,7 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 	if arrowType, ok := stringTypeToArrowTypeMap[col]; ok {
 		return arrowType, nil
 	}
+	// match the IPC return type from Databricks
 	if strings.EqualFold(col, "TIMESTAMP") || strings.EqualFold(col, "TIMESTAMP_NTZ") {
 		return &arrow.TimestampType{
 			Unit:     arrow.Microsecond,
@@ -250,6 +251,7 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 		}
 
 		var scale = 0
+		// Match scale if present
 		if len(matches) > 2 && matches[2] != "" {
 			parsed_scale, err := strToInt(matches[2])
 			if err != nil {
@@ -396,7 +398,6 @@ func parseStructField(field string) (fieldName, fieldType string, nullable bool,
 // extracts the field type and determines nullability
 // todo(jason): handle comments and collations (if they show up from the API)
 func extractFieldTypeAndModifiers(rest string) (fieldType string, nullable bool) {
-	// Default to nullable
 	nullable = true
 
 	// Split by whitespace to find modifiers

--- a/go/adbc/driver/databricks/schema.go
+++ b/go/adbc/driver/databricks/schema.go
@@ -30,12 +30,11 @@ import (
 const DbxSchemaTypeText = "type_text"
 
 const (
-	decimalTypeRegex        = `^(?:DECIMAL|DEC|NUMERIC)\((\d+)(?:,(\d+))?\)$`
-	arrayTypeRegex          = `^ARRAY<(.*)>$`
-	mapTypeRegex            = `^MAP<(.*)>$`
-	structTypeRegex         = `^STRUCT<(.*)>$`
-	intervalTypeRegex       = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)$`
-	intervalTypePrefixRegex = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)`
+	decimalTypeRegex  = `^(?:DECIMAL|DEC|NUMERIC)\((\d+)(?:,(\d+))?\)$`
+	arrayTypeRegex    = `^ARRAY<(.*)>$`
+	mapTypeRegex      = `^MAP<(.*)>$`
+	structTypeRegex   = `^STRUCT<(.*)>$`
+	intervalTypeRegex = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)`
 )
 
 // Basic DBX Types to Arrow Types (no extra processing needed)
@@ -375,7 +374,7 @@ func findTypeEnd(s string) int {
 	dt := &depthTracker{}
 	if strings.HasPrefix(s, "INTERVAL") {
 		// Match INTERVAL types at the start
-		intervalRegex := regexp.MustCompile(intervalTypePrefixRegex)
+		intervalRegex := regexp.MustCompile(intervalTypeRegex)
 		if m := intervalRegex.FindStringIndex(s); m != nil {
 			return m[1]
 		}

--- a/go/adbc/driver/databricks/schema.go
+++ b/go/adbc/driver/databricks/schema.go
@@ -29,6 +29,15 @@ import (
 
 const DbxSchemaTypeText = "type_text"
 
+const (
+	decimalTypeRegex        = `^(?:DECIMAL|DEC|NUMERIC)\((\d+)(?:,(\d+))?\)$`
+	arrayTypeRegex          = `^ARRAY<(.*)>$`
+	mapTypeRegex            = `^MAP<(.*)>$`
+	structTypeRegex         = `^STRUCT<(.*)>$`
+	intervalTypeRegex       = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)$`
+	intervalTypePrefixRegex = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)`
+)
+
 // Basic DBX Types to Arrow Types (no extra processing needed)
 // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-datatypes
 var basicTypeToArrowTypeMap = map[sql.ColumnInfoTypeName]arrow.DataType{
@@ -50,6 +59,58 @@ var basicTypeToArrowTypeMap = map[sql.ColumnInfoTypeName]arrow.DataType{
 	sql.ColumnInfoTypeNameBinary:  arrow.BinaryTypes.Binary,      // byte sequence values
 	sql.ColumnInfoTypeNameBoolean: arrow.FixedWidthTypes.Boolean, // Boolean values
 	sql.ColumnInfoTypeNameNull:    arrow.Null,                    // untyped NULL - not supported by Delta Lake
+}
+
+var stringTypeToArrowTypeMap = map[string]arrow.DataType{
+	// Integral numeric types (whole numbers)
+	"TINYINT":  arrow.PrimitiveTypes.Int8,  // 1-byte signed integer
+	"BYTE":     arrow.PrimitiveTypes.Int8,  // 1-byte signed integer
+	"SMALLINT": arrow.PrimitiveTypes.Int16, // 2-byte signed integer
+	"SHORT":    arrow.PrimitiveTypes.Int16, // 2-byte signed integer
+	"INT":      arrow.PrimitiveTypes.Int32, // 4-byte signed integer
+	"INTEGER":  arrow.PrimitiveTypes.Int32, // 4-byte signed integer
+	"LONG":     arrow.PrimitiveTypes.Int64, // 8-byte signed integer
+	"BIGINT":   arrow.PrimitiveTypes.Int64, // 8-byte signed integer
+
+	// Binary floating point types
+	"FLOAT":  arrow.PrimitiveTypes.Float32, // 4-byte single-precision
+	"REAL":   arrow.PrimitiveTypes.Float32, // 4-byte single-precision
+	"DOUBLE": arrow.PrimitiveTypes.Float64, // 8-byte double-precision
+
+	// Date-time types
+	"DATE": arrow.FixedWidthTypes.Date32, // year, month, day without timezone
+
+	// Simple types
+	"STRING":  arrow.BinaryTypes.String,      // character string values
+	"BINARY":  arrow.BinaryTypes.Binary,      // byte sequence values
+	"BOOLEAN": arrow.FixedWidthTypes.Boolean, // Boolean values
+	"VOID":    arrow.Null,                    // untyped NULL - not supported by Delta Lake
+	"NULL":    arrow.Null,                    // untyped NULL - not supported by Delta Lake
+}
+
+// tracks bracket and parenthesis depth for parsing nested types
+type depthTracker struct {
+	bracketDepth int
+	parenDepth   int
+}
+
+// updates the depth counters based on the given character
+func (dt *depthTracker) updateDepth(char byte) {
+	switch char {
+	case '<':
+		dt.bracketDepth++
+	case '>':
+		dt.bracketDepth--
+	case '(':
+		dt.parenDepth++
+	case ')':
+		dt.parenDepth--
+	}
+}
+
+// returns true if both bracket and parenthesis depths are 0
+func (dt *depthTracker) isAtTopLevel() bool {
+	return dt.bracketDepth == 0 && dt.parenDepth == 0
 }
 
 func ClusterModeSchemaToArrowSchema(dbxSchema []map[string]interface{}) (*arrow.Schema, error) {
@@ -128,6 +189,241 @@ func ResultSchemaToArrowSchema(dbxSchema *sql.ResultSchema) (*arrow.Schema, erro
 	return arrow.NewSchema(fields, &metadata), nil
 }
 
+// Basic recursive descent parsing
+func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
+	// handle simple, non-recursive types
+	if arrowType, ok := stringTypeToArrowTypeMap[col]; ok {
+		return arrowType, nil
+	}
+	if col == "TIMESTAMP" || col == "TIMESTAMP_NTZ" {
+		return &arrow.TimestampType{
+			Unit:     arrow.Microsecond,
+			TimeZone: "Etc/UTC",
+		}, nil
+	}
+	// { DECIMAL | DEC | NUMERIC } [ (  p [ , s ] ) ]
+	if matches := regexp.MustCompile(decimalTypeRegex).FindStringSubmatch(col); matches != nil {
+		var err error
+		var precision64 int64
+		precision64, err = strconv.ParseInt(matches[1], 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid decimal precision: %v", err)
+		}
+		precision := int(precision64)
+
+		var scale = 0
+		if len(matches) > 2 && matches[2] != "" {
+			var scale64 int64
+			scale64, err = strconv.ParseInt(matches[2], 10, 8)
+			if err != nil {
+				return nil, fmt.Errorf("invalid decimal scale: %v", err)
+			}
+			scale = int(scale64)
+		}
+
+		return &arrow.Decimal128Type{Precision: int32(precision), Scale: int32(scale)}, nil
+	}
+	// ARRAY < elementType >
+	if matches := regexp.MustCompile(arrayTypeRegex).FindStringSubmatch(col); matches != nil {
+		elementType := strings.TrimSpace(matches[1])
+		elementArrowType, err := getArrowTypeFromStringType(elementType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse array element type: %w", err)
+		}
+		return arrow.ListOf(elementArrowType), nil
+	}
+	// MAP <keyType, valueType>
+	if matches := regexp.MustCompile(mapTypeRegex).FindStringSubmatch(col); matches != nil {
+		// Parse key and value types, handling nested commas
+		keyType, valueType, err := parseMapKeyValue(matches[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid map type format: %w", err)
+		}
+
+		keyArrowType, err := getArrowTypeFromStringType(keyType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse map key type: %w", err)
+		}
+		valueArrowType, err := getArrowTypeFromStringType(valueType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse map value type: %w", err)
+		}
+		return arrow.MapOf(keyArrowType, valueArrowType), nil
+	}
+	// INTERVAL types - comprehensive pattern for all interval types
+	if matches := regexp.MustCompile(intervalTypeRegex).FindStringSubmatch(col); matches != nil {
+		// Year-month intervals
+		if strings.Contains(matches[1], "YEAR") || matches[1] == "MONTH" {
+			return arrow.FixedWidthTypes.MonthInterval, nil
+		}
+		// All other intervals are day-time intervals
+		return arrow.FixedWidthTypes.Duration_s, nil
+	}
+	// STRUCT: STRUCT < [fieldName [:] fieldType [NOT NULL] [COLLATE collationName] [COMMENT str] [, …] ] >
+	if matches := regexp.MustCompile(structTypeRegex).FindStringSubmatch(col); matches != nil {
+		inner := matches[1]
+		fields := parseStructFields(inner)
+		arrowFields := make([]arrow.Field, 0, len(fields))
+		// Parse field name and type (fieldName: fieldType)
+		for _, field := range fields {
+			fieldName, fieldType, nullable, err := parseStructField(field)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse struct field '%s': %w", field, err)
+			}
+
+			// Recursively parse the field type
+			fieldArrowType, err := getArrowTypeFromStringType(fieldType)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse struct field type %s: %w", fieldName, err)
+			}
+
+			arrowFields = append(arrowFields, arrow.Field{
+				Name:     fieldName,
+				Type:     fieldArrowType,
+				Nullable: nullable,
+			})
+		}
+		return arrow.StructOf(arrowFields...), nil
+	}
+	// default to an unrecognized type so we can still positionally propogate metadata
+	return arrow.Null, fmt.Errorf("unrecognized type: %s", col)
+}
+
+// parses comma separated struct fields and handles nesting
+func parseStructFields(fieldsStr string) []string {
+	var fields []string
+	var currentField strings.Builder
+	dt := &depthTracker{}
+
+	for i := 0; i < len(fieldsStr); i++ {
+		char := fieldsStr[i]
+
+		switch char {
+		case '<', '>', '(', ')':
+			dt.updateDepth(char)
+			currentField.WriteByte(char)
+		case ',':
+			if dt.isAtTopLevel() {
+				// This comma separates fields, not nested type parameters
+				field := strings.TrimSpace(currentField.String())
+				if field != "" {
+					fields = append(fields, field)
+				}
+				currentField.Reset()
+				continue
+			} else {
+				// This comma is inside brackets or parentheses, so it's part of the type
+				currentField.WriteByte(char)
+			}
+		default:
+			currentField.WriteByte(char)
+		}
+	}
+	// last field
+	field := strings.TrimSpace(currentField.String())
+	if field != "" {
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+// parses a single struct field
+func parseStructField(field string) (fieldName, fieldType string, nullable bool, err error) {
+	// Split on first colon to get field name and the rest
+	parts := strings.SplitN(field, ":", 2)
+	if len(parts) != 2 {
+		return "", "", true, fmt.Errorf("invalid struct field format: missing colon")
+	}
+
+	fieldName = strings.TrimSpace(parts[0])
+	rest := strings.TrimSpace(parts[1])
+
+	// Extract field type and modifiers
+	fieldType, nullable = extractFieldTypeAndModifiers(rest)
+
+	return fieldName, fieldType, nullable, nil
+}
+
+// extracts the field type and determines nullability
+// todo(jason): handle comments and collations (if they show up from the API)
+func extractFieldTypeAndModifiers(rest string) (fieldType string, nullable bool) {
+	// Default to nullable
+	nullable = true
+
+	// Split by whitespace to find modifiers
+	parts := strings.Fields(rest)
+	if len(parts) == 0 {
+		return "", true
+	}
+
+	// The first part is the base type, but it might contain nested parentheses
+	// We need to find where the type ends and modifiers begin
+	typeEnd := findTypeEnd(rest)
+	fieldType = strings.TrimSpace(rest[:typeEnd])
+
+	// Check for NOT NULL modifier
+	remaining := strings.TrimSpace(rest[typeEnd:])
+	if strings.Contains(strings.ToUpper(remaining), "NOT NULL") {
+		nullable = false
+	}
+
+	return fieldType, nullable
+}
+
+// finds the end of the type definition, handling nested brackets and multi-word types
+func findTypeEnd(s string) int {
+	dt := &depthTracker{}
+	if strings.HasPrefix(s, "INTERVAL") {
+		// Match INTERVAL types at the start
+		intervalRegex := regexp.MustCompile(intervalTypePrefixRegex)
+		if m := intervalRegex.FindStringIndex(s); m != nil {
+			return m[1]
+		}
+	}
+	for i := 0; i < len(s); i++ {
+		char := s[i]
+		switch char {
+		case '<', '>':
+			dt.updateDepth(char)
+		case ' ':
+			if dt.isAtTopLevel() {
+				return i
+			}
+		}
+	}
+	return len(s)
+}
+
+// parseMapKeyValue parses the key and value types from a MAP type string
+func parseMapKeyValue(mapContent string) (keyType, valueType string, err error) {
+	var currentType strings.Builder
+	dt := &depthTracker{}
+
+	for i := 0; i < len(mapContent); i++ {
+		char := mapContent[i]
+
+		switch char {
+		case '<', '>', '(', ')':
+			dt.updateDepth(char)
+			currentType.WriteByte(char)
+		case ',':
+			if dt.isAtTopLevel() {
+				// This comma separates key and value types
+				keyType = strings.TrimSpace(currentType.String())
+				valueType = strings.TrimSpace(mapContent[i+1:])
+				return keyType, valueType, nil
+			} else {
+				// This comma is inside nested brackets or parentheses, so it's part of the type
+				currentType.WriteByte(char)
+			}
+		default:
+			currentType.WriteByte(char)
+		}
+	}
+
+	return "", "", fmt.Errorf("no comma found to separate key and value types")
+}
+
 func getArrowTypeFromColumnInfo(col sql.ColumnInfo) (arrow.DataType, error) {
 	if arrowType, ok := basicTypeToArrowTypeMap[col.TypeName]; ok {
 		return arrowType, nil
@@ -136,27 +432,7 @@ func getArrowTypeFromColumnInfo(col sql.ColumnInfo) (arrow.DataType, error) {
 	case sql.ColumnInfoTypeNameDecimal:
 		precision, scale := col.TypePrecision, col.TypeScale
 		if precision == 0 {
-			// Mostly used by the recursive case (array, map, etc)
-			// "DECIMAL(p,s) and DECIMAL(p) with scale default at 0"
-			if matches := regexp.MustCompile(`DECIMAL\((\d+)(?:,?(\d+))?\)`).FindStringSubmatch(col.TypeText); matches != nil {
-				var err error
-				var precision64 int64
-				precision64, err = strconv.ParseInt(matches[1], 10, 8)
-				if err != nil {
-					return nil, fmt.Errorf("invalid decimal precision: %v", err)
-				}
-				precision = int(precision64)
-
-				// expect 3 matches total: DECIMAL, p, s
-				if len(matches) == 3 {
-					var scale64 int64
-					scale64, err = strconv.ParseInt(matches[2], 10, 8)
-					if err != nil {
-						return nil, fmt.Errorf("invalid decimal scale: %v", err)
-					}
-					scale = int(scale64)
-				}
-			}
+			return getArrowTypeFromStringType(col.TypeText)
 		}
 		if precision <= 38 {
 			return &arrow.Decimal128Type{Precision: int32(precision), Scale: int32(scale)}, nil
@@ -168,142 +444,12 @@ func getArrowTypeFromColumnInfo(col sql.ColumnInfo) (arrow.DataType, error) {
 			Unit:     arrow.Microsecond,
 			TimeZone: "Etc/UTC", // todo(jasonlin45): Support session timezone
 		}, nil
-	case sql.ColumnInfoTypeNameArray:
-		// Only available from the full SQL type spec
-		// parse from "ARRAY<elementType>"
-		if matches := regexp.MustCompile(`ARRAY<(.+)>`).FindStringSubmatch(col.TypeText); matches != nil {
-			elementType := strings.TrimSpace(matches[1])
-			// Create a temporary ColumnInfo to recursively parse the element type
-			elementCol := sql.ColumnInfo{
-				TypeName: sql.ColumnInfoTypeName(elementType),
-			}
-
-			elementArrowType, err := getArrowTypeFromColumnInfo(elementCol)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse array element type: %w", err)
-			}
-			return arrow.ListOf(elementArrowType), nil
-		}
-		return nil, fmt.Errorf("invalid array type format: %v", col.TypeName)
-	case sql.ColumnInfoTypeNameMap:
-		// "MAP<keyType,valueType>"
-		if matches := regexp.MustCompile(`MAP<(.+),(.+)>`).FindStringSubmatch(col.TypeText); matches != nil {
-			keyType := strings.TrimSpace(matches[1])
-			valueType := strings.TrimSpace(matches[2])
-
-			// temporary ColumnInfo structs to recursively parse the types
-			keyCol := sql.ColumnInfo{
-				TypeName: sql.ColumnInfoTypeName(keyType),
-			}
-			valueCol := sql.ColumnInfo{
-				TypeName: sql.ColumnInfoTypeName(valueType),
-			}
-
-			keyArrowType, err := getArrowTypeFromColumnInfo(keyCol)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse map key type: %w", err)
-			}
-			valueArrowType, err := getArrowTypeFromColumnInfo(valueCol)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse map value type: %w", err)
-			}
-
-			return arrow.MapOf(keyArrowType, valueArrowType), nil
-		}
-		return nil, fmt.Errorf("invalid map type format: %v", col.TypeName)
-	case sql.ColumnInfoTypeNameStruct:
-		// todo(jasonlin45): Full support for struct field. No support for NOT NULL, COLLATE or COMMENT available
-		// STRUCT < [fieldName [:] fieldType [NOT NULL] [COLLATE collationName] [COMMENT str] [, …] ] >
-		if matches := regexp.MustCompile(`STRUCT<(.+)>`).FindStringSubmatch(col.TypeText); matches != nil {
-			fieldsStr := matches[1]
-
-			fields := []string{}
-
-			// fields are comma separated, nested types are in parentheses
-			fieldRegex := regexp.MustCompile(`([^,()]+(?:\([^()]*\)[^,()]*)*)`)
-			matches := fieldRegex.FindAllString(fieldsStr, -1)
-			for _, field := range matches {
-				fields = append(fields, strings.TrimSpace(field))
-			}
-
-			// Parse each field
-			arrowFields := make([]arrow.Field, 0, len(fields))
-			for _, field := range fields {
-				// Split on first colon to get field name and type
-				parts := strings.SplitN(field, ":", 2)
-				if len(parts) != 2 {
-					return nil, fmt.Errorf("invalid struct field format: %s", field)
-				}
-				fieldName := strings.TrimSpace(parts[0])
-				fieldType := strings.TrimSpace(parts[1])
-
-				// Create temporary ColumnInfo to parse the field type
-				fieldCol := sql.ColumnInfo{
-					TypeName: sql.ColumnInfoTypeName(fieldType),
-				}
-
-				fieldArrowType, err := getArrowTypeFromColumnInfo(fieldCol)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse struct field type %s: %w", fieldName, err)
-				}
-
-				arrowFields = append(arrowFields, arrow.Field{
-					Name:     fieldName,
-					Type:     fieldArrowType,
-					Nullable: true,
-				})
-			}
-
-			return arrow.StructOf(arrowFields...), nil
-		}
-		return nil, fmt.Errorf("invalid struct type format: %v", col.TypeName)
-	case sql.ColumnInfoTypeNameInterval:
-		/* Syntax
-		INTERVAL { yearMonthIntervalQualifier | dayTimeIntervalQualifier }
-
-		yearMonthIntervalQualifier
-		 { YEAR [TO MONTH] |
-		   MONTH }
-
-		dayTimeIntervalQualifier
-		 { DAY [TO { HOUR | MINUTE | SECOND } ] |
-		   HOUR [TO { MINUTE | SECOND } ] |
-		   MINUTE [TO SECOND] |
-		   SECOND }
-		*/
-		// Helper function to map interval units to Arrow type
-		getIntervalType := func(startUnit, endUnit string) (arrow.DataType, error) {
-			switch {
-			case startUnit == "YEAR" && (endUnit == "" || endUnit == "MONTH"):
-				return arrow.FixedWidthTypes.MonthInterval, nil
-			default:
-				return nil, fmt.Errorf("unsupported interval qualifier: %s TO %s", startUnit, endUnit)
-			}
-		}
-
-		// First try to use TypeIntervalType if available
-		if col.TypeIntervalType != "" {
-			// Split into start and end units
-			parts := strings.Split(col.TypeIntervalType, " TO ")
-			startUnit := parts[0]
-			endUnit := ""
-			if len(parts) > 1 {
-				endUnit = parts[1]
-			}
-			return getIntervalType(startUnit, endUnit)
-		}
-
-		// Fall back to parsing TypeText for recursive calls
-		if matches := regexp.MustCompile(`INTERVAL\s+(\w+)(?:\s+TO\s+(\w+))?`).FindStringSubmatch(col.TypeText); matches != nil {
-			startUnit := strings.ToUpper(matches[1])
-			endUnit := ""
-			if len(matches) > 2 {
-				endUnit = strings.ToUpper(matches[2])
-			}
-			return getIntervalType(startUnit, endUnit)
-		}
-		return nil, fmt.Errorf("invalid interval type format: %v", col.TypeText)
+	case sql.ColumnInfoTypeNameArray,
+		sql.ColumnInfoTypeNameMap,
+		sql.ColumnInfoTypeNameStruct,
+		sql.ColumnInfoTypeNameInterval:
+		return getArrowTypeFromStringType(col.TypeText)
 	default:
-		return nil, fmt.Errorf("unsupported type: %v", col.TypeName)
+		return getArrowTypeFromStringType(col.TypeText)
 	}
 }

--- a/go/adbc/driver/databricks/schema.go
+++ b/go/adbc/driver/databricks/schema.go
@@ -31,9 +31,6 @@ const DbxSchemaTypeText = "type_text"
 
 const (
 	decimalTypeRegex  = `^(?:DECIMAL|DEC|NUMERIC)\((\d+)(?:,(\d+))?\)$`
-	arrayTypeRegex    = `^ARRAY<(.*)>$`
-	mapTypeRegex      = `^MAP<(.*)>$`
-	structTypeRegex   = `^STRUCT<(.*)>$`
 	intervalTypeRegex = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)`
 )
 
@@ -89,27 +86,36 @@ var stringTypeToArrowTypeMap = map[string]arrow.DataType{
 
 // tracks bracket and parenthesis depth for parsing nested types
 type depthTracker struct {
-	bracketDepth int
-	parenDepth   int
+	stack []byte
+}
+
+var delimiterMap = map[byte]byte{
+	')': '(',
+	'>': '<',
 }
 
 // updates the depth counters based on the given character
-func (dt *depthTracker) updateDepth(char byte) {
+func (dt *depthTracker) updateDepth(char byte) error {
 	switch char {
-	case '<':
-		dt.bracketDepth++
-	case '>':
-		dt.bracketDepth--
-	case '(':
-		dt.parenDepth++
-	case ')':
-		dt.parenDepth--
+	case '<', '(':
+		dt.stack = append(dt.stack, char)
+	case '>', ')':
+		if len(dt.stack) == 0 {
+			return fmt.Errorf("unmatched closing delimiter '%c' (empty stack)", char)
+		}
+		expected := delimiterMap[char]
+		actual := dt.stack[len(dt.stack)-1]
+		if actual != expected {
+			return fmt.Errorf("unmatched closing delimiter '%c' (expected '%c', got '%c')", char, expected, actual)
+		}
+		dt.stack = dt.stack[:len(dt.stack)-1]
 	}
+	return nil
 }
 
-// returns true if both bracket and parenthesis depths are 0
+// returns true if the stack is empty (at top level)
 func (dt *depthTracker) isAtTopLevel() bool {
-	return dt.bracketDepth == 0 && dt.parenDepth == 0
+	return len(dt.stack) == 0
 }
 
 func ClusterModeSchemaToArrowSchema(dbxSchema []map[string]interface{}) (*arrow.Schema, error) {
@@ -188,9 +194,30 @@ func ResultSchemaToArrowSchema(dbxSchema *sql.ResultSchema) (*arrow.Schema, erro
 	return arrow.NewSchema(fields, &metadata), nil
 }
 
-// Basic recursive descent parsing
+// extracts the content between the outermost <...> after the given prefix.
+func extractOutermostBracketContent(s, prefix string) (string, bool) {
+	if !strings.HasPrefix(s, prefix+"<") || !strings.HasSuffix(s, ">") {
+		return "", false
+	}
+	start := len(prefix) + 1
+	depth := 0
+	for i := start; i < len(s); i++ {
+		if s[i] == '<' {
+			depth++
+		} else if s[i] == '>' {
+			if depth == 0 {
+				// Found the matching closing bracket
+				return s[start:i], true
+			}
+			depth--
+		}
+	}
+	// If we get here, brackets were unbalanced
+	return "", false
+}
+
 func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
-	// handle simple, non-recursive types
+	// simple types - base case
 	if arrowType, ok := stringTypeToArrowTypeMap[col]; ok {
 		return arrowType, nil
 	}
@@ -223,22 +250,19 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 		return &arrow.Decimal128Type{Precision: int32(precision), Scale: int32(scale)}, nil
 	}
 	// ARRAY < elementType >
-	if matches := regexp.MustCompile(arrayTypeRegex).FindStringSubmatch(col); matches != nil {
-		elementType := strings.TrimSpace(matches[1])
-		elementArrowType, err := getArrowTypeFromStringType(elementType)
+	if content, ok := extractOutermostBracketContent(col, "ARRAY"); ok {
+		elementArrowType, err := getArrowTypeFromStringType(strings.TrimSpace(content))
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse array element type: %w", err)
 		}
 		return arrow.ListOf(elementArrowType), nil
 	}
 	// MAP <keyType, valueType>
-	if matches := regexp.MustCompile(mapTypeRegex).FindStringSubmatch(col); matches != nil {
-		// Parse key and value types, handling nested commas
-		keyType, valueType, err := parseMapKeyValue(matches[1])
+	if content, ok := extractOutermostBracketContent(col, "MAP"); ok {
+		keyType, valueType, err := parseMapKeyValue(content)
 		if err != nil {
 			return nil, fmt.Errorf("invalid map type format: %w", err)
 		}
-
 		keyArrowType, err := getArrowTypeFromStringType(keyType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse map key type: %w", err)
@@ -258,24 +282,22 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 		// All other intervals are day-time intervals
 		return arrow.FixedWidthTypes.Duration_s, nil
 	}
-	// STRUCT: STRUCT < [fieldName [:] fieldType [NOT NULL] [COLLATE collationName] [COMMENT str] [, …] ] >
-	if matches := regexp.MustCompile(structTypeRegex).FindStringSubmatch(col); matches != nil {
-		inner := matches[1]
-		fields := parseStructFields(inner)
+	// STRUCT < [fieldName [:] fieldType [NOT NULL] [COLLATE collationName] [COMMENT str] [, …] ] >
+	if content, ok := extractOutermostBracketContent(col, "STRUCT"); ok {
+		fields, err := parseStructFields(content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse struct: %w", err)
+		}
 		arrowFields := make([]arrow.Field, 0, len(fields))
-		// Parse field name and type (fieldName: fieldType)
 		for _, field := range fields {
 			fieldName, fieldType, nullable, err := parseStructField(field)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse struct field '%s': %w", field, err)
 			}
-
-			// Recursively parse the field type
 			fieldArrowType, err := getArrowTypeFromStringType(fieldType)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse struct field type %s: %w", fieldName, err)
 			}
-
 			arrowFields = append(arrowFields, arrow.Field{
 				Name:     fieldName,
 				Type:     fieldArrowType,
@@ -289,7 +311,7 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 }
 
 // parses comma separated struct fields and handles nesting
-func parseStructFields(fieldsStr string) []string {
+func parseStructFields(fieldsStr string) ([]string, error) {
 	var fields []string
 	var currentField strings.Builder
 	dt := &depthTracker{}
@@ -299,7 +321,10 @@ func parseStructFields(fieldsStr string) []string {
 
 		switch char {
 		case '<', '>', '(', ')':
-			dt.updateDepth(char)
+			err := dt.updateDepth(char)
+			if err != nil {
+				return nil, err
+			}
 			currentField.WriteByte(char)
 		case ',':
 			if dt.isAtTopLevel() {
@@ -323,7 +348,8 @@ func parseStructFields(fieldsStr string) []string {
 	if field != "" {
 		fields = append(fields, field)
 	}
-	return fields
+
+	return fields, nil
 }
 
 // parses a single struct field

--- a/go/adbc/driver/databricks/schema.go
+++ b/go/adbc/driver/databricks/schema.go
@@ -30,8 +30,13 @@ import (
 const DbxSchemaTypeText = "type_text"
 
 const (
-	decimalTypeRegex  = `^(?:DECIMAL|DEC|NUMERIC)\((\d+)(?:,(\d+))?\)$`
-	intervalTypeRegex = `^INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)`
+	decimalTypeRegexRaw  = `(?i)^\s*(?:DECIMAL|DEC|NUMERIC)\s*\(\s*(\d+)\s*(?:,\s*(\d+)\s*)?\)\s*$`
+	intervalTypeRegexRaw = `(?i)^\s*INTERVAL\s+(YEAR(?:\s+TO\s+MONTH)?|MONTH|DAY(?:\s+TO\s+(HOUR|MINUTE|SECOND))?|HOUR(?:\s+TO\s+(MINUTE|SECOND))?|MINUTE(?:\s+TO\s+SECOND)?|SECOND)`
+)
+
+var (
+	decimalTypeRegex  = regexp.MustCompile(decimalTypeRegexRaw)
+	intervalTypeRegex = regexp.MustCompile(intervalTypeRegexRaw)
 )
 
 // Basic DBX Types to Arrow Types (no extra processing needed)
@@ -82,6 +87,15 @@ var stringTypeToArrowTypeMap = map[string]arrow.DataType{
 	"BOOLEAN": arrow.FixedWidthTypes.Boolean, // Boolean values
 	"VOID":    arrow.Null,                    // untyped NULL - not supported by Delta Lake
 	"NULL":    arrow.Null,                    // untyped NULL - not supported by Delta Lake
+}
+
+func strToInt(str string) (int, error) {
+	// expect base 10, parse to 8 bits
+	out, err := strconv.ParseInt(str, 10, 8)
+	if err != nil {
+		return 0, err
+	}
+	return int(out), nil
 }
 
 // tracks bracket and parenthesis depth for parsing nested types
@@ -147,8 +161,8 @@ func ClusterModeSchemaToArrowSchema(dbxSchema []map[string]interface{}) (*arrow.
 		case strings.HasPrefix(colType, "decimal"):
 			// Parse decimal precision and scale from format "decimal(precision,scale)"
 			if matches := regexp.MustCompile(`decimal\((\d+),(\d+)\)`).FindStringSubmatch(colType); matches != nil {
-				precision, _ := strconv.ParseInt(matches[1], 10, 8)
-				scale, _ := strconv.ParseInt(matches[2], 10, 8)
+				precision, _ := strToInt(matches[1])
+				scale, _ := strToInt(matches[2])
 				arrowType = &arrow.Decimal128Type{Precision: int32(precision), Scale: int32(scale)}
 			} else {
 				arrowType = &arrow.Decimal128Type{}
@@ -196,7 +210,7 @@ func ResultSchemaToArrowSchema(dbxSchema *sql.ResultSchema) (*arrow.Schema, erro
 
 // extracts the content between the outermost <...> after the given prefix.
 func extractOutermostBracketContent(s, prefix string) (string, bool) {
-	if !strings.HasPrefix(s, prefix+"<") || !strings.HasSuffix(s, ">") {
+	if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(s)), strings.ToUpper(prefix)+"<") || !strings.HasSuffix(strings.TrimSpace(s), ">") {
 		return "", false
 	}
 	start := len(prefix) + 1
@@ -221,30 +235,27 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 	if arrowType, ok := stringTypeToArrowTypeMap[col]; ok {
 		return arrowType, nil
 	}
-	if col == "TIMESTAMP" || col == "TIMESTAMP_NTZ" {
+	if strings.EqualFold(col, "TIMESTAMP") || strings.EqualFold(col, "TIMESTAMP_NTZ") {
 		return &arrow.TimestampType{
 			Unit:     arrow.Microsecond,
 			TimeZone: "Etc/UTC",
 		}, nil
 	}
 	// { DECIMAL | DEC | NUMERIC } [ (  p [ , s ] ) ]
-	if matches := regexp.MustCompile(decimalTypeRegex).FindStringSubmatch(col); matches != nil {
+	if matches := decimalTypeRegex.FindStringSubmatch(col); matches != nil {
 		var err error
-		var precision64 int64
-		precision64, err = strconv.ParseInt(matches[1], 10, 8)
+		precision, err := strToInt(matches[1])
 		if err != nil {
 			return nil, fmt.Errorf("invalid decimal precision: %v", err)
 		}
-		precision := int(precision64)
 
 		var scale = 0
 		if len(matches) > 2 && matches[2] != "" {
-			var scale64 int64
-			scale64, err = strconv.ParseInt(matches[2], 10, 8)
+			parsed_scale, err := strToInt(matches[2])
 			if err != nil {
 				return nil, fmt.Errorf("invalid decimal scale: %v", err)
 			}
-			scale = int(scale64)
+			scale = parsed_scale
 		}
 
 		return &arrow.Decimal128Type{Precision: int32(precision), Scale: int32(scale)}, nil
@@ -274,7 +285,7 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 		return arrow.MapOf(keyArrowType, valueArrowType), nil
 	}
 	// INTERVAL types - comprehensive pattern for all interval types
-	if matches := regexp.MustCompile(intervalTypeRegex).FindStringSubmatch(col); matches != nil {
+	if matches := intervalTypeRegex.FindStringSubmatch(col); matches != nil {
 		// Year-month intervals
 		if strings.Contains(matches[1], "YEAR") || matches[1] == "MONTH" {
 			return arrow.FixedWidthTypes.MonthInterval, nil
@@ -306,7 +317,7 @@ func getArrowTypeFromStringType(col string) (arrow.DataType, error) {
 		}
 		return arrow.StructOf(arrowFields...), nil
 	}
-	// default to an unrecognized type so we can still positionally propogate metadata
+	// Use Null to occupy schema column position, so metadata remains correctly aligned even when the type is unrecognized.
 	return arrow.Null, fmt.Errorf("unrecognized type: %s", col)
 }
 
@@ -315,20 +326,33 @@ func parseStructFields(fieldsStr string) ([]string, error) {
 	var fields []string
 	var currentField strings.Builder
 	dt := &depthTracker{}
+	inQuotes := false
 
 	for i := 0; i < len(fieldsStr); i++ {
 		char := fieldsStr[i]
 
 		switch char {
+		case '"':
+			// Handle quoted strings, but check for escaped quotes
+			if i > 0 && fieldsStr[i-1] == '\\' {
+				// This is an escaped quote, treat as regular character
+				currentField.WriteByte(char)
+			} else {
+				// Toggle quote state
+				inQuotes = !inQuotes
+				currentField.WriteByte(char)
+			}
 		case '<', '>', '(', ')':
-			err := dt.updateDepth(char)
-			if err != nil {
-				return nil, err
+			if !inQuotes {
+				err := dt.updateDepth(char)
+				if err != nil {
+					return nil, err
+				}
 			}
 			currentField.WriteByte(char)
 		case ',':
-			if dt.isAtTopLevel() {
-				// This comma separates fields, not nested type parameters
+			if !inQuotes && dt.isAtTopLevel() {
+				// This comma separates fields, not nested type parameters or quoted content
 				field := strings.TrimSpace(currentField.String())
 				if field != "" {
 					fields = append(fields, field)
@@ -336,7 +360,7 @@ func parseStructFields(fieldsStr string) ([]string, error) {
 				currentField.Reset()
 				continue
 			} else {
-				// This comma is inside brackets or parentheses, so it's part of the type
+				// This comma is inside brackets, parentheses, or quotes, so it's part of the type
 				currentField.WriteByte(char)
 			}
 		default:
@@ -381,15 +405,29 @@ func extractFieldTypeAndModifiers(rest string) (fieldType string, nullable bool)
 		return "", true
 	}
 
-	// The first part is the base type, but it might contain nested parentheses
-	// We need to find where the type ends and modifiers begin
-	typeEnd := findTypeEnd(rest)
-	fieldType = strings.TrimSpace(rest[:typeEnd])
+	// For simple types (one word), use the first word as the type
+	// For complex types with brackets, use findTypeEnd
+	if strings.ContainsAny(parts[0], "<>()") || strings.HasPrefix(strings.ToUpper(rest), "INTERVAL") {
+		// Complex type - use findTypeEnd to handle nested brackets
+		typeEnd := findTypeEnd(rest)
+		fieldType = strings.TrimSpace(rest[:typeEnd])
+		remaining := strings.TrimSpace(rest[typeEnd:])
 
-	// Check for NOT NULL modifier
-	remaining := strings.TrimSpace(rest[typeEnd:])
-	if strings.Contains(strings.ToUpper(remaining), "NOT NULL") {
-		nullable = false
+		// Check for NOT NULL modifier
+		if strings.Contains(strings.ToUpper(remaining), "NOT NULL") {
+			nullable = false
+		}
+	} else {
+		// Simple type - first word is the type, rest are modifiers
+		fieldType = parts[0]
+
+		// Join remaining parts and check for NOT NULL
+		if len(parts) > 1 {
+			remaining := strings.Join(parts[1:], " ")
+			if strings.Contains(strings.ToUpper(remaining), "NOT NULL") {
+				nullable = false
+			}
+		}
 	}
 
 	return fieldType, nullable
@@ -398,20 +436,31 @@ func extractFieldTypeAndModifiers(rest string) (fieldType string, nullable bool)
 // finds the end of the type definition, handling nested brackets and multi-word types
 func findTypeEnd(s string) int {
 	dt := &depthTracker{}
+	inQuotes := false
+
 	if strings.HasPrefix(s, "INTERVAL") {
 		// Match INTERVAL types at the start
-		intervalRegex := regexp.MustCompile(intervalTypeRegex)
-		if m := intervalRegex.FindStringIndex(s); m != nil {
+		if m := intervalTypeRegex.FindStringIndex(s); m != nil {
 			return m[1]
 		}
 	}
 	for i := 0; i < len(s); i++ {
 		char := s[i]
 		switch char {
+		case '"':
+			// Handle quoted strings, but check for escaped quotes
+			if i > 0 && s[i-1] == '\\' {
+				// This is an escaped quote, continue
+			} else {
+				// Toggle quote state
+				inQuotes = !inQuotes
+			}
 		case '<', '>':
-			dt.updateDepth(char)
+			if !inQuotes {
+				dt.updateDepth(char)
+			}
 		case ' ':
-			if dt.isAtTopLevel() {
+			if !inQuotes && dt.isAtTopLevel() {
 				return i
 			}
 		}
@@ -457,7 +506,7 @@ func getArrowTypeFromColumnInfo(col sql.ColumnInfo) (arrow.DataType, error) {
 	case sql.ColumnInfoTypeNameDecimal:
 		precision, scale := col.TypePrecision, col.TypeScale
 		if precision == 0 {
-			return getArrowTypeFromStringType(col.TypeText)
+			return getArrowTypeFromStringType(strings.TrimSpace(col.TypeText))
 		}
 		if precision <= 38 {
 			return &arrow.Decimal128Type{Precision: int32(precision), Scale: int32(scale)}, nil
@@ -473,8 +522,8 @@ func getArrowTypeFromColumnInfo(col sql.ColumnInfo) (arrow.DataType, error) {
 		sql.ColumnInfoTypeNameMap,
 		sql.ColumnInfoTypeNameStruct,
 		sql.ColumnInfoTypeNameInterval:
-		return getArrowTypeFromStringType(col.TypeText)
+		return getArrowTypeFromStringType(strings.TrimSpace(col.TypeText))
 	default:
-		return getArrowTypeFromStringType(col.TypeText)
+		return getArrowTypeFromStringType(strings.TrimSpace(col.TypeText))
 	}
 }

--- a/go/adbc/driver/databricks/schema_test.go
+++ b/go/adbc/driver/databricks/schema_test.go
@@ -198,6 +198,7 @@ func TestGetArrowTypeFromColumnInfo(t *testing.T) {
 			col: sql.ColumnInfo{
 				TypeName:         sql.ColumnInfoTypeNameInterval,
 				TypeIntervalType: "YEAR TO MONTH",
+				TypeText:         "INTERVAL YEAR TO MONTH",
 			},
 			expected: arrow.FixedWidthTypes.MonthInterval,
 		},
@@ -239,6 +240,250 @@ func TestGetArrowTypeFromColumnInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getArrowTypeFromColumnInfo(tt.col)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetArrowTypeFromStringType(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeText string
+		expected arrow.DataType
+		wantErr  bool
+	}{
+		// DECIMAL types
+		{
+			name:     "decimal type with precision and scale",
+			typeText: "DECIMAL(5,2)",
+			expected: &arrow.Decimal128Type{Precision: 5, Scale: 2},
+		},
+		{
+			name:     "decimal type with precision only",
+			typeText: "DECIMAL(10)",
+			expected: &arrow.Decimal128Type{Precision: 10, Scale: 0},
+		},
+		{
+			name:     "dec type with precision and scale",
+			typeText: "DEC(8,3)",
+			expected: &arrow.Decimal128Type{Precision: 8, Scale: 3},
+		},
+		{
+			name:     "numeric type with precision and scale",
+			typeText: "NUMERIC(15,4)",
+			expected: &arrow.Decimal128Type{Precision: 15, Scale: 4},
+		},
+
+		// ARRAY types
+		{
+			name:     "array of int",
+			typeText: "ARRAY<INT>",
+			expected: arrow.ListOf(arrow.PrimitiveTypes.Int32),
+		},
+		{
+			name:     "array of string",
+			typeText: "ARRAY<STRING>",
+			expected: arrow.ListOf(arrow.BinaryTypes.String),
+		},
+		{
+			name:     "array of decimal",
+			typeText: "ARRAY<DECIMAL(10,2)>",
+			expected: arrow.ListOf(&arrow.Decimal128Type{Precision: 10, Scale: 2}),
+		},
+		{
+			name:     "nested array",
+			typeText: "ARRAY<ARRAY<INT>>",
+			expected: arrow.ListOf(arrow.ListOf(arrow.PrimitiveTypes.Int32)),
+		},
+
+		// MAP types
+		{
+			name:     "map of string to int",
+			typeText: "MAP<STRING,INT>",
+			expected: arrow.MapOf(arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int32),
+		},
+		{
+			name:     "map of int to string",
+			typeText: "MAP<INT,STRING>",
+			expected: arrow.MapOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String),
+		},
+		{
+			name:     "map with complex key and value",
+			typeText: "MAP<DECIMAL(5,2),ARRAY<STRING>>",
+			expected: arrow.MapOf(&arrow.Decimal128Type{Precision: 5, Scale: 2}, arrow.ListOf(arrow.BinaryTypes.String)),
+		},
+
+		// STRUCT types
+		{
+			name:     "struct with basic fields",
+			typeText: "STRUCT<id:INT,name:STRING,active:BOOLEAN>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+				arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+				arrow.Field{Name: "active", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+			),
+		},
+		{
+			name:     "struct with not null field",
+			typeText: "STRUCT<id:INT NOT NULL,name:STRING>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+				arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+			),
+		},
+		{
+			name:     "struct with nested types",
+			typeText: "STRUCT<data:ARRAY<INT>,metadata:MAP<STRING,STRING>>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "data", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+				arrow.Field{Name: "metadata", Type: arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String), Nullable: true},
+			),
+		},
+		{
+			name:     "struct with nested decimal",
+			typeText: "STRUCT<data:ARRAY<INT>,metadata:MAP<DECIMAL(10,2),STRING>>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "data", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+				arrow.Field{Name: "metadata", Type: arrow.MapOf(&arrow.Decimal128Type{Precision: 10, Scale: 2}, arrow.BinaryTypes.String), Nullable: true},
+			),
+		},
+		{
+			name:     "struct with interval type",
+			typeText: "STRUCT<data:ARRAY<INT>,metadata:MAP<DECIMAL(10,2),INTERVAL MONTH>>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "data", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+				arrow.Field{Name: "metadata", Type: arrow.MapOf(&arrow.Decimal128Type{Precision: 10, Scale: 2}, arrow.FixedWidthTypes.MonthInterval), Nullable: true},
+			),
+		},
+		{
+			name:     "struct with decimal and interval type",
+			typeText: "STRUCT<data:ARRAY<INT>,dece:DECIMAL(8,8),inter:INTERVAL MONTH>>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "data", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+				arrow.Field{Name: "dece", Type: &arrow.Decimal128Type{Precision: 8, Scale: 8}, Nullable: true},
+				arrow.Field{Name: "inter", Type: arrow.FixedWidthTypes.MonthInterval, Nullable: true},
+			),
+		},
+		{
+			name:     "struct with nested struct",
+			typeText: "STRUCT<address:STRUCT<street:STRING,city:STRING>,age:INT>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "address", Type: arrow.StructOf(
+					arrow.Field{Name: "street", Type: arrow.BinaryTypes.String, Nullable: true},
+					arrow.Field{Name: "city", Type: arrow.BinaryTypes.String, Nullable: true},
+				), Nullable: true},
+				arrow.Field{Name: "age", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+			),
+		},
+
+		// INTERVAL types
+		{
+			name:     "year to month interval",
+			typeText: "INTERVAL YEAR TO MONTH",
+			expected: arrow.FixedWidthTypes.MonthInterval,
+		},
+		{
+			name:     "year interval",
+			typeText: "INTERVAL YEAR",
+			expected: arrow.FixedWidthTypes.MonthInterval,
+		},
+		{
+			name:     "month interval",
+			typeText: "INTERVAL MONTH",
+			expected: arrow.FixedWidthTypes.MonthInterval,
+		},
+		{
+			name:     "day to hour interval",
+			typeText: "INTERVAL DAY TO HOUR",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "day to minute interval",
+			typeText: "INTERVAL DAY TO MINUTE",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "day to second interval",
+			typeText: "INTERVAL DAY TO SECOND",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "hour to minute interval",
+			typeText: "INTERVAL HOUR TO MINUTE",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "hour to second interval",
+			typeText: "INTERVAL HOUR TO SECOND",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "minute to second interval",
+			typeText: "INTERVAL MINUTE TO SECOND",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "day interval",
+			typeText: "INTERVAL DAY",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "hour interval",
+			typeText: "INTERVAL HOUR",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "minute interval",
+			typeText: "INTERVAL MINUTE",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+		{
+			name:     "second interval",
+			typeText: "INTERVAL SECOND",
+			expected: arrow.FixedWidthTypes.Duration_s,
+		},
+
+		// Error cases
+		{
+			name:     "invalid decimal format",
+			typeText: "DECIMAL(abc,def)",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid array format",
+			typeText: "ARRAY<",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid map format",
+			typeText: "MAP<STRING>",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid struct format",
+			typeText: "STRUCT<id:INT,name>",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid interval format",
+			typeText: "INTERVAL INVALID",
+			wantErr:  true,
+		},
+		{
+			name:     "unrecognized type",
+			typeText: "UNKNOWN_TYPE",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getArrowTypeFromStringType(tt.typeText)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/go/adbc/driver/databricks/schema_test.go
+++ b/go/adbc/driver/databricks/schema_test.go
@@ -337,8 +337,24 @@ func TestGetArrowTypeFromStringType(t *testing.T) {
 			),
 		},
 		{
+			name:     "struct with extra whitespace",
+			typeText: "STRUCT<id: INT  NOT  NULL,    name : STRING>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+				arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+			),
+		},
+		{
 			name:     "struct with nested types",
 			typeText: "STRUCT<data:ARRAY<INT>,metadata:MAP<STRING,STRING>>",
+			expected: arrow.StructOf(
+				arrow.Field{Name: "data", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+				arrow.Field{Name: "metadata", Type: arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String), Nullable: true},
+			),
+		},
+		{
+			name:     "struct with comments",
+			typeText: "STRUCT<data:ARRAY<INT> COMMENT \"blah blah blah\",metadata:MAP<STRING,STRING>>",
 			expected: arrow.StructOf(
 				arrow.Field{Name: "data", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
 				arrow.Field{Name: "metadata", Type: arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String), Nullable: true},

--- a/go/adbc/driver/databricks/stmt_record_reader.go
+++ b/go/adbc/driver/databricks/stmt_record_reader.go
@@ -117,8 +117,7 @@ func newRecordReader(
 	ctx, cancelFn := context.WithCancel(ctx)
 	arrowSchema, err := ResultSchemaToArrowSchema(manifest.Schema)
 	if err != nil {
-		cancelFn()
-		return nil, fmt.Errorf("unable to parse schema from manifest: %v", err)
+		log.Fatalf("unable to parse schema from manifest: %v", err)
 	}
 	r := &statementReader{
 		refCount: 1,
@@ -263,10 +262,9 @@ func (r *statementReader) Schema() *arrow.Schema {
 		for i := range fields {
 			field := r.schema.Field(i)
 			derivedField := r.derivedSchema.Field(i)
-			// todo(jasonlin45): introduce some sort of logging here when it's less noisy so we can surface these
-			// if field.Type.Fingerprint() != derivedField.Type.Fingerprint() {
-			// fmt.Printf("schema type mismatch at field %d (%s): expected %v, got %v", derivedField.Type, field.Type)
-			// }
+			if field.Type.Fingerprint() != derivedField.Type.Fingerprint() {
+				log.Printf("schema type mismatch at field %d (%s): expected %v, got %v", i, field.Name, derivedField.Type, field.Type)
+			}
 			field.Metadata = derivedField.Metadata
 			fields[i] = field
 		}


### PR DESCRIPTION
# Summary
This change adds full support for parsing types from the raw type text when they come back from SQL warehouses in Databricks.

All of the data types as specified on this page should be supported:
https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-datatypes

I've also adjusted the behavior to return a null column when we fail to parse so we can positionally propagate metadata to the IPC types.

# Demo

https://github.com/user-attachments/assets/af15516b-6b2b-413a-93ba-23a7893adccd


