### PR TITLE
(go/adbc/bigquery) preliminary support of seed ingestion in bigquery

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -508,9 +508,9 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	}
 	switch c.authType {
 	case OptionValueAuthTypeJSONCredentialFile,
-	    OptionValueAuthTypeJSONCredentialString,
-	    OptionValueAuthTypeUserAuthentication,
-	    OptionValueAuthTypeTemporaryAccessToken:
+		OptionValueAuthTypeJSONCredentialString,
+		OptionValueAuthTypeUserAuthentication,
+		OptionValueAuthTypeTemporaryAccessToken:
 		var credentials option.ClientOption
 
 		switch c.authType {

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -66,10 +66,10 @@ type connectionImpl struct {
 	client *bigquery.Client
 }
 
+// Helper for configuration of a connection for use with a job
 func (c *connectionImpl) table(project, dataset, table string) *bigquery.Table {
     return c.client.DatasetInProject(project, dataset).Table(table)
 }
-
 
 func (c *connectionImpl) GetCatalogs(ctx context.Context, catalogFilter *string) ([]string, error) {
 	catalogPattern, err := internal.PatternToRegexp(catalogFilter)

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -66,6 +66,11 @@ type connectionImpl struct {
 	client *bigquery.Client
 }
 
+func (c *connectionImpl) table(project, dataset, table string) *bigquery.Table {
+    return c.client.DatasetInProject(project, dataset).Table(table)
+}
+
+
 func (c *connectionImpl) GetCatalogs(ctx context.Context, catalogFilter *string) ([]string, error) {
 	catalogPattern, err := internal.PatternToRegexp(catalogFilter)
 	if err != nil {

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -513,9 +513,9 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	}
 	switch c.authType {
 	case OptionValueAuthTypeJSONCredentialFile,
-		OptionValueAuthTypeJSONCredentialString,
-		OptionValueAuthTypeUserAuthentication,
-		OptionValueAuthTypeTemporaryAccessToken:
+	    OptionValueAuthTypeJSONCredentialString,
+	    OptionValueAuthTypeUserAuthentication,
+	    OptionValueAuthTypeTemporaryAccessToken:
 		var credentials option.ClientOption
 
 		switch c.authType {

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package bigquery
 
 import (

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -19,7 +19,6 @@ package bigquery
 
 import (
 	"context"
-	"strings"
 	"testing"
 )
 

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -83,11 +83,11 @@ func TestCustomAccessTokenEndpoint(t *testing.T) {
 
 func TestTemporaryAccessToken_Valid(t *testing.T) {
 	conn := &connectionImpl{
-		authType:     "adbc.bigquery.sql.auth_type.temporary_access_token",
-		catalog:      "test-project-id",
-		dbSchema:     "test-dataset-id",
-		tableID:      "test-table-id",
-		accessToken:  "ya29.fake-access-token-for-test",
+		authType:    "adbc.bigquery.sql.auth_type.temporary_access_token",
+		catalog:     "test-project-id",
+		dbSchema:    "test-dataset-id",
+		tableID:     "test-table-id",
+		accessToken: "ya29.fake-access-token-for-test",
 	}
 
 	err := conn.newClient(context.Background())

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -81,6 +81,9 @@ const (
 
 	DefaultAccessTokenEndpoint   = "https://accounts.google.com/o/oauth2/token"
 	DefaultAccessTokenServerName = "google.com"
+
+	OptionStringIngestFileDelimiter = "adbc.bigquery.ingest_file_delimiter"
+	OptionStringIngestPath          = "adbc.bigquery.ingest_path"
 )
 
 var (

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -82,8 +82,8 @@ const (
 	DefaultAccessTokenEndpoint   = "https://accounts.google.com/o/oauth2/token"
 	DefaultAccessTokenServerName = "google.com"
 
-	OptionStringIngestFileDelimiter = "adbc.bigquery.ingest_file_delimiter"
-	OptionStringIngestPath          = "adbc.bigquery.ingest_path"
+	OptionStringIngestFileDelimiter = "adbc.bigquery.ingest.csv_delimiter"
+	OptionStringIngestPath          = "adbc.bigquery.ingest.csv_filepath"
 )
 
 var (
@@ -128,6 +128,23 @@ func (d *driverImpl) NewDatabase(opts map[string]string) (adbc.Database, error) 
 	}
 
 	return driverbase.NewDatabase(db), nil
+}
+
+func parseParts(defaultProjectID, defaultDatasetID, value string) (string, string, string, error) {
+	parts := strings.Split(value, ".")
+	switch len(parts) {
+	case 1:
+		return defaultProjectID, defaultDatasetID, parts[0], nil
+	case 2:
+		return defaultProjectID, parts[0], parts[1], nil
+	case 3:
+		return parts[0], parts[1], parts[2], nil
+	default:
+		return "", "", "", adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  fmt.Sprintf("invalid table reference %q (want [[project.]dataset.]table)", value),
+		}
+	}
 }
 
 func stringToTable(defaultProjectID, defaultDatasetID, value string) (*bigquery.Table, error) {

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -148,28 +148,15 @@ func parseParts(defaultProjectID, defaultDatasetID, value string) (string, strin
 }
 
 func stringToTable(defaultProjectID, defaultDatasetID, value string) (*bigquery.Table, error) {
-	parts := strings.Split(value, ".")
-	table := &bigquery.Table{
-		ProjectID: defaultProjectID,
-		DatasetID: defaultDatasetID,
+	projectID, datasetID, tableID, err := parseParts(defaultProjectID, defaultDatasetID, value)
+	if err != nil {
+		return nil, err
 	}
-	switch len(parts) {
-	case 1:
-		table.TableID = parts[0]
-	case 2:
-		table.DatasetID = parts[0]
-		table.TableID = parts[1]
-	case 3:
-		table.ProjectID = parts[0]
-		table.DatasetID = parts[1]
-		table.TableID = parts[2]
-	default:
-		return nil, adbc.Error{
-			Code: adbc.StatusInvalidArgument,
-			Msg:  fmt.Sprintf("Invalid Table Reference format, expected `[[ProjectId.]DatasetId.]TableId`, got: `%s`", value),
-		}
-	}
-	return table, nil
+	return &bigquery.Table{
+		ProjectID: projectID,
+		DatasetID: datasetID,
+		TableID:   tableID,
+	}, nil
 }
 
 func stringToTableCreateDisposition(value string) (bigquery.TableCreateDisposition, error) {

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -54,8 +54,8 @@ type statement struct {
 	prefetchConcurrency    int
 
 	// Ingest related fields
-	isIngest     bool
-	ingestPath   string
+	isIngest            bool
+	ingestPath          string
 	ingestFileDelimiter string
 }
 
@@ -266,7 +266,7 @@ func (st *statement) SetOption(key string, v string) error {
 		st.ingestFileDelimiter = v
 	case adbc.OptionKeyIngestMode:
 		switch v {
-		case adbc.OptionValueIngestModeCreateAppend,  adbc.OptionValueIngestModeAppend:
+		case adbc.OptionValueIngestModeCreateAppend, adbc.OptionValueIngestModeAppend:
 			st.queryConfig.WriteDisposition = bigquery.WriteAppend
 		case adbc.OptionValueIngestModeReplace:
 			st.queryConfig.WriteDisposition = bigquery.WriteTruncate
@@ -528,102 +528,102 @@ func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.Sta
 
 func arrowFieldToBigQueryField(arrowField arrow.Field) (bigquery.FieldSchema, error) {
 	switch arrowField.Type.ID() {
-		case arrow.BOOL:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type: bigquery.StringFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.IntegerFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.FloatFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.BINARY, arrow.BINARY_VIEW, arrow.LARGE_BINARY, arrow.FIXED_SIZE_BINARY:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.BytesFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.STRING, arrow.STRING_VIEW, arrow.LARGE_STRING:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.StringFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.TIMESTAMP:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.TimestampFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.TIME32, arrow.TIME64:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.TimeFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.DECIMAL128:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.NumericFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.DECIMAL256:
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.BigNumericFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
-			elemField := arrowField.Type.(*arrow.ListType).ElemField()
-			elemType, err := arrowFieldToBigQueryField(elemField)
-			if err != nil {
-				return bigquery.FieldSchema{}, err
-			}
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     elemType.Type,
-				Required: !arrowField.Nullable,
-				Repeated: true,
-			}, nil
-		case arrow.STRUCT:
-			// ToDo: implement structs schema generation
-			return bigquery.FieldSchema{
-				Name:     arrowField.Name,
-				Type:     bigquery.RecordFieldType,
-				Required: !arrowField.Nullable,
-			}, nil
-		default:
-			// todo: implement all other types
-			//
-			// - arrow.DURATION
-			//   For arrow.DURATION, I'm not sure which SQL DataType would be a good
-			//   representation for it. `DATETIME` could be a potential one for it,
-			//   if we count from `0000-01-01T00:00:00.000000Z`
-			//
-			// - arrow.INTERVAL_MONTHS
-			// - arrow.INTERVAL_DAY_TIME
-			// - arrow.INTERVAL_MONTH_DAY_NANO
-			//   `DATETIME` could be a potential fit for all interval types, but
-			//   the issue is there's no rules about how many days are in a month.
-			//
-			// - arrow.RUN_END_ENCODED
-			// - arrow.SPARSE_UNION
-			// - arrow.DENSE_UNION
-			// - arrow.DICTIONARY
-			// - arrow.MAP
-			return bigquery.FieldSchema{}, adbc.Error{
-				Code: adbc.StatusNotImplemented,
-				Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", arrowField.Type.ID()),
-			}
+	case arrow.BOOL:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.StringFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.IntegerFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.FloatFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.BINARY, arrow.BINARY_VIEW, arrow.LARGE_BINARY, arrow.FIXED_SIZE_BINARY:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.BytesFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.STRING, arrow.STRING_VIEW, arrow.LARGE_STRING:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.StringFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.TIMESTAMP:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.TimestampFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.TIME32, arrow.TIME64:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.TimeFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.DECIMAL128:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.NumericFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.DECIMAL256:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.BigNumericFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+		elemField := arrowField.Type.(*arrow.ListType).ElemField()
+		elemType, err := arrowFieldToBigQueryField(elemField)
+		if err != nil {
+			return bigquery.FieldSchema{}, err
+		}
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     elemType.Type,
+			Required: !arrowField.Nullable,
+			Repeated: true,
+		}, nil
+	case arrow.STRUCT:
+		// ToDo: implement structs schema generation
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.RecordFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	default:
+		// todo: implement all other types
+		//
+		// - arrow.DURATION
+		//   For arrow.DURATION, I'm not sure which SQL DataType would be a good
+		//   representation for it. `DATETIME` could be a potential one for it,
+		//   if we count from `0000-01-01T00:00:00.000000Z`
+		//
+		// - arrow.INTERVAL_MONTHS
+		// - arrow.INTERVAL_DAY_TIME
+		// - arrow.INTERVAL_MONTH_DAY_NANO
+		//   `DATETIME` could be a potential fit for all interval types, but
+		//   the issue is there's no rules about how many days are in a month.
+		//
+		// - arrow.RUN_END_ENCODED
+		// - arrow.SPARSE_UNION
+		// - arrow.DENSE_UNION
+		// - arrow.DICTIONARY
+		// - arrow.MAP
+		return bigquery.FieldSchema{}, adbc.Error{
+			Code: adbc.StatusNotImplemented,
+			Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", arrowField.Type.ID()),
+		}
 	}
 }
 
@@ -946,7 +946,7 @@ func (st *statement) initIngest(ctx context.Context) error {
 
 	// Set file format configuration
 	job.Src.(*bigquery.ReaderSource).FileConfig.SourceFormat = bigquery.CSV
-	job.Src.(*bigquery.ReaderSource).FileConfig.SkipLeadingRows = 1  // Skip header row
+	job.Src.(*bigquery.ReaderSource).FileConfig.SkipLeadingRows = 1                     // Skip header row
 	job.Src.(*bigquery.ReaderSource).FileConfig.FieldDelimiter = st.ingestFileDelimiter // Default CSV delimiter
 
 	// Convert Arrow schema to BigQuery schema if provided

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -518,7 +518,7 @@ func arrowFieldToBigQueryField(arrowField arrow.Field) (bigquery.FieldSchema, er
 	case arrow.BOOL:
 		return bigquery.FieldSchema{
 			Name:     arrowField.Name,
-			Type:     bigquery.StringFieldType,
+			Type:     bigquery.BooleanFieldType,
 			Required: !arrowField.Nullable,
 		}, nil
 	case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
@@ -549,6 +549,12 @@ func arrowFieldToBigQueryField(arrowField arrow.Field) (bigquery.FieldSchema, er
 		return bigquery.FieldSchema{
 			Name:     arrowField.Name,
 			Type:     bigquery.TimestampFieldType,
+			Required: !arrowField.Nullable,
+		}, nil
+	case arrow.DATE32, arrow.DATE64:
+		return bigquery.FieldSchema{
+			Name:     arrowField.Name,
+			Type:     bigquery.DateFieldType,
 			Required: !arrowField.Nullable,
 		}, nil
 	case arrow.TIME32, arrow.TIME64:
@@ -622,8 +628,8 @@ func arrowSchemaToBigQuery(schema *arrow.Schema) (bigquery.Schema, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		bqSchema[i] = &bqField
+		copy := bqField 	// distinct memory
+		bqSchema[i] = &copy
 	}
 	return bqSchema, nil
 }
@@ -943,17 +949,6 @@ func (st *statement) initIngest(ctx context.Context) error {
 	fileCfg.SourceFormat = bigquery.CSV // TODO: parameterize for other files
 	fileCfg.SkipLeadingRows = 1
 	fileCfg.FieldDelimiter = st.ingestFileDelimiter
-
-	// Optional: print schema if param binding exists
-	if st.paramBinding != nil {
-		schema := st.paramBinding.Schema()
-
-		bqSchema, err := arrowSchemaToBigQuery(schema)
-		if err != nil {
-			return fmt.Errorf("failed to convert schema: %w", err)
-		}
-		fileCfg.Schema = bqSchema
-	}
 
 	handle, err := job.Run(ctx)
 	if err != nil {

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -186,12 +186,11 @@ func (st *statement) SetOption(key string, v string) error {
 			}
 		}
 	case OptionStringQueryDestinationTable:
-		val, err := stringToTable(st.cnxn.catalog, st.cnxn.dbSchema, v)
-		if err == nil {
-			st.queryConfig.Dst = val
-		} else {
+		proj, ds, tbl, err := parseParts(st.cnxn.catalog, st.cnxn.dbSchema, v)
+		if err != nil {
 			return err
 		}
+		st.queryConfig.Dst = st.cnxn.table(proj, ds, tbl)
 	case OptionStringQueryDefaultProjectID:
 		st.queryConfig.DefaultProjectID = v
 	case OptionStringQueryDefaultDatasetID:
@@ -930,38 +929,55 @@ func (st *statement) initIngest(ctx context.Context) error {
 		}
 	}
 
-	// Open the local file
+	// Open file
 	file, err := os.Open(st.ingestPath)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
 
-	// Create a reader source from the file
+	if st.queryConfig.Dst == nil {
+		panic("PANIC: queryConfig.Dst is nil — project_id, dataset_id, table_id likely not set")
+	}
+	if st.queryConfig.Dst.ProjectID == "" {
+		panic("PANIC: ProjectID is empty on queryConfig.Dst")
+	}
+
 	loadSource := bigquery.NewReaderSource(file)
+	// carry schema over
+	loadSource.AutoDetect = true
 	job := st.queryConfig.Dst.LoaderFrom(loadSource)
 
-	// Configure the load job
 	job.WriteDisposition = st.queryConfig.WriteDisposition
 
-	// Set file format configuration
-	job.Src.(*bigquery.ReaderSource).FileConfig.SourceFormat = bigquery.CSV
-	job.Src.(*bigquery.ReaderSource).FileConfig.SkipLeadingRows = 1                     // Skip header row
-	job.Src.(*bigquery.ReaderSource).FileConfig.FieldDelimiter = st.ingestFileDelimiter // Default CSV delimiter
+	// Set file config
+	fileCfg := &job.Src.(*bigquery.ReaderSource).FileConfig
+	fileCfg.SourceFormat = bigquery.CSV // TODO: parameterize for other files
+	fileCfg.SkipLeadingRows = 1
+	fileCfg.FieldDelimiter = st.ingestFileDelimiter
 
-	// Convert Arrow schema to BigQuery schema if provided
+	// Optional: print schema if param binding exists
 	if st.paramBinding != nil {
-		bqSchema, err := arrowSchemaToBigQuery(st.paramBinding.Schema())
+		schema := st.paramBinding.Schema()
+
+		bqSchema, err := arrowSchemaToBigQuery(schema)
 		if err != nil {
 			return fmt.Errorf("failed to convert schema: %w", err)
 		}
-		job.Src.(*bigquery.ReaderSource).FileConfig.Schema = bqSchema
+		fileCfg.Schema = bqSchema
 	}
 
-	// Run the load job
-	_, err = job.Run(ctx)
+	handle, err := job.Run(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to run load job: %w", err)
+		return fmt.Errorf("failed to start query job: %w", err)
+	}
+
+	status, err := handle.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("job wait failed: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("job execution failed: %w", status.Err())
 	}
 
 	return nil

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -263,18 +263,6 @@ func (st *statement) SetOption(key string, v string) error {
 		st.ingestPath = v
 	case OptionStringIngestFileDelimiter:
 		st.ingestFileDelimiter = v
-	case adbc.OptionKeyIngestMode:
-		switch v {
-		case adbc.OptionValueIngestModeCreateAppend, adbc.OptionValueIngestModeAppend:
-			st.queryConfig.WriteDisposition = bigquery.WriteAppend
-		case adbc.OptionValueIngestModeReplace:
-			st.queryConfig.WriteDisposition = bigquery.WriteTruncate
-		default:
-			return adbc.Error{
-				Code: adbc.StatusInvalidArgument,
-				Msg:  fmt.Sprintf("unsupported ingest mode `%s`", v),
-			}
-		}
 	default:
 		return adbc.Error{
 			Code: adbc.StatusInvalidArgument,

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -20,6 +20,7 @@ package bigquery
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -51,6 +52,11 @@ type statement struct {
 	streamBinding          array.RecordReader
 	resultRecordBufferSize int
 	prefetchConcurrency    int
+
+	// Ingest related fields
+	isIngest     bool
+	ingestPath   string
+	ingestFileDelimiter string
 }
 
 func (st *statement) GetOptionBytes(key string) ([]byte, error) {
@@ -132,6 +138,11 @@ func (st *statement) GetOption(key string) (string, error) {
 		return strconv.FormatBool(st.queryConfig.DryRun), nil
 	case OptionBoolQueryCreateSession:
 		return strconv.FormatBool(st.queryConfig.CreateSession), nil
+	case OptionStringIngestFileDelimiter:
+		return st.ingestFileDelimiter, nil
+	case OptionStringIngestPath:
+		return st.ingestPath, nil
+
 	default:
 		val, err := st.cnxn.GetOption(key)
 		if err == nil {
@@ -248,7 +259,23 @@ func (st *statement) SetOption(key string, v string) error {
 		} else {
 			return err
 		}
-
+	case OptionStringIngestPath:
+		st.isIngest = true
+		st.ingestPath = v
+	case OptionStringIngestFileDelimiter:
+		st.ingestFileDelimiter = v
+	case adbc.OptionKeyIngestMode:
+		switch v {
+		case adbc.OptionValueIngestModeCreateAppend,  adbc.OptionValueIngestModeAppend:
+			st.queryConfig.WriteDisposition = bigquery.WriteAppend
+		case adbc.OptionValueIngestModeReplace:
+			st.queryConfig.WriteDisposition = bigquery.WriteTruncate
+		default:
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("unsupported ingest mode `%s`", v),
+			}
+		}
 	default:
 		return adbc.Error{
 			Code: adbc.StatusInvalidArgument,
@@ -297,6 +324,10 @@ func (st *statement) SetSqlQuery(query string) error {
 //
 // This invalidates any prior result sets on this statement.
 func (st *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, int64, error) {
+	if st.isIngest {
+		return st.executeIngest(ctx)
+	}
+
 	if st.queryConfig.Q == "" {
 		return nil, -1, adbc.Error{
 			Msg:  "cannot execute without a query",
@@ -493,6 +524,121 @@ func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.Sta
 			Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", value.DataType().ID()),
 		}
 	}
+}
+
+func arrowFieldToBigQueryField(arrowField arrow.Field) (bigquery.FieldSchema, error) {
+	switch arrowField.Type.ID() {
+		case arrow.BOOL:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type: bigquery.StringFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.IntegerFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.FloatFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.BINARY, arrow.BINARY_VIEW, arrow.LARGE_BINARY, arrow.FIXED_SIZE_BINARY:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.BytesFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.STRING, arrow.STRING_VIEW, arrow.LARGE_STRING:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.StringFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.TIMESTAMP:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.TimestampFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.TIME32, arrow.TIME64:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.TimeFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.DECIMAL128:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.NumericFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.DECIMAL256:
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.BigNumericFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+			elemField := arrowField.Type.(*arrow.ListType).ElemField()
+			elemType, err := arrowFieldToBigQueryField(elemField)
+			if err != nil {
+				return bigquery.FieldSchema{}, err
+			}
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     elemType.Type,
+				Required: !arrowField.Nullable,
+				Repeated: true,
+			}, nil
+		case arrow.STRUCT:
+			// ToDo: implement structs schema generation
+			return bigquery.FieldSchema{
+				Name:     arrowField.Name,
+				Type:     bigquery.RecordFieldType,
+				Required: !arrowField.Nullable,
+			}, nil
+		default:
+			// todo: implement all other types
+			//
+			// - arrow.DURATION
+			//   For arrow.DURATION, I'm not sure which SQL DataType would be a good
+			//   representation for it. `DATETIME` could be a potential one for it,
+			//   if we count from `0000-01-01T00:00:00.000000Z`
+			//
+			// - arrow.INTERVAL_MONTHS
+			// - arrow.INTERVAL_DAY_TIME
+			// - arrow.INTERVAL_MONTH_DAY_NANO
+			//   `DATETIME` could be a potential fit for all interval types, but
+			//   the issue is there's no rules about how many days are in a month.
+			//
+			// - arrow.RUN_END_ENCODED
+			// - arrow.SPARSE_UNION
+			// - arrow.DENSE_UNION
+			// - arrow.DICTIONARY
+			// - arrow.MAP
+			return bigquery.FieldSchema{}, adbc.Error{
+				Code: adbc.StatusNotImplemented,
+				Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", arrowField.Type.ID()),
+			}
+	}
+}
+
+// arrowSchemaToBigQuery converts an Arrow schema to a BigQuery schema
+func arrowSchemaToBigQuery(schema *arrow.Schema) (bigquery.Schema, error) {
+	bqSchema := make(bigquery.Schema, len(schema.Fields()))
+	for i, field := range schema.Fields() {
+		bqField, err := arrowFieldToBigQueryField(field)
+		if err != nil {
+			return nil, err
+		}
+
+		bqSchema[i] = &bqField
+	}
+	return bqSchema, nil
 }
 
 func arrowValueToQueryParameterValue(field arrow.Field, value arrow.Array, i int) (bigquery.QueryParameter, error) {
@@ -774,6 +920,68 @@ func (st *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc
 		Code: adbc.StatusNotImplemented,
 		Msg:  "ExecutePartitions not yet implemented for BigQuery driver",
 	}
+}
+
+func (st *statement) initIngest(ctx context.Context) error {
+	if st.ingestPath == "" {
+		return adbc.Error{
+			Code: adbc.StatusInvalidState,
+			Msg:  "cannot execute ingest without a file path",
+		}
+	}
+
+	// Open the local file
+	file, err := os.Open(st.ingestPath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	// Create a reader source from the file
+	loadSource := bigquery.NewReaderSource(file)
+	job := st.queryConfig.Dst.LoaderFrom(loadSource)
+
+	// Configure the load job
+	job.WriteDisposition = st.queryConfig.WriteDisposition
+
+	// Set file format configuration
+	job.Src.(*bigquery.ReaderSource).FileConfig.SourceFormat = bigquery.CSV
+	job.Src.(*bigquery.ReaderSource).FileConfig.SkipLeadingRows = 1  // Skip header row
+	job.Src.(*bigquery.ReaderSource).FileConfig.FieldDelimiter = st.ingestFileDelimiter // Default CSV delimiter
+
+	// Convert Arrow schema to BigQuery schema if provided
+	if st.paramBinding != nil {
+		bqSchema, err := arrowSchemaToBigQuery(st.paramBinding.Schema())
+		if err != nil {
+			return fmt.Errorf("failed to convert schema: %w", err)
+		}
+		job.Src.(*bigquery.ReaderSource).FileConfig.Schema = bqSchema
+	}
+
+	// Run the load job
+	_, err = job.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run load job: %w", err)
+	}
+
+	return nil
+}
+
+func (st *statement) executeIngest(ctx context.Context) (array.RecordReader, int64, error) {
+	err := st.initIngest(ctx)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	// For ingest operations, we return an empty record reader since there's no result set
+	emptySchema := arrow.NewSchema([]arrow.Field{}, nil)
+	emptyRecord := array.NewRecord(emptySchema, []arrow.Array{}, 0)
+	reader, err := array.NewRecordReader(emptySchema, []arrow.Record{emptyRecord})
+	if err != nil {
+		return nil, -1, err
+	}
+
+	return reader, 0, nil
 }
 
 var _ adbc.GetSetOptions = (*statement)(nil)

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -18,11 +18,16 @@
 package bigquery
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
+	"unicode"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/apache/arrow-adbc/go/adbc"
@@ -54,7 +59,6 @@ type statement struct {
 	prefetchConcurrency    int
 
 	// Ingest related fields
-	isIngest            bool
 	ingestPath          string
 	ingestFileDelimiter string
 }
@@ -259,7 +263,6 @@ func (st *statement) SetOption(key string, v string) error {
 			return err
 		}
 	case OptionStringIngestPath:
-		st.isIngest = true
 		st.ingestPath = v
 	case OptionStringIngestFileDelimiter:
 		st.ingestFileDelimiter = v
@@ -311,7 +314,7 @@ func (st *statement) SetSqlQuery(query string) error {
 //
 // This invalidates any prior result sets on this statement.
 func (st *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, int64, error) {
-	if st.isIngest {
+	if st.ingestPath != "" {
 		return st.executeIngest(ctx)
 	}
 
@@ -409,6 +412,23 @@ func (st *statement) query() *bigquery.Query {
 	query := st.cnxn.client.Query("")
 	query.QueryConfig = st.queryConfig
 	return query
+}
+
+func listMeta(f arrow.Field, arr arrow.Array) (elemField arrow.Field, listValues arrow.Array, err error) {
+	switch lt := f.Type.(type) {
+	case *arrow.ListType:
+		return lt.ElemField(), arr.(*array.List).ListValues(), nil
+	case *arrow.LargeListType:
+		return lt.ElemField(), arr.(*array.LargeList).ListValues(), nil
+	case *arrow.FixedSizeListType:
+		return lt.ElemField(), arr.(*array.FixedSizeList).ListValues(), nil
+	case *arrow.ListViewType:
+		return lt.ElemField(), arr.(*array.ListView).ListValues(), nil
+	case *arrow.LargeListViewType:
+		return lt.ElemField(), arr.(*array.LargeListView).ListValues(), nil
+	default:
+		return arrow.Field{}, nil, fmt.Errorf("unsupported list type %T", f.Type)
+	}
 }
 
 func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.StandardSQLDataType, error) {
@@ -899,6 +919,89 @@ func (st *statement) GetParameterSchema() (*arrow.Schema, error) {
 	}
 }
 
+func detectArrowType(sample string) arrow.DataType {
+	s := strings.TrimSpace(sample)
+	if s == "" {
+		// empty first row → keep as STRING so later NULLs are possible
+		return arrow.BinaryTypes.String
+	}
+
+	// ----- BOOL -----
+	if strings.EqualFold(s, "true") || strings.EqualFold(s, "false") {
+		return arrow.FixedWidthTypes.Boolean
+	}
+
+	// ----- INT64 ----
+	if _, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return arrow.PrimitiveTypes.Int64
+	}
+
+	// ----- FLOAT64 --
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return arrow.PrimitiveTypes.Float64
+	}
+
+	// ----- DATE -----
+	if _, err := time.Parse("2006-01-02", s); err == nil {
+		return arrow.FixedWidthTypes.Date32
+	}
+
+	// ----- TIMESTAMP (RFC 3339) -----
+	if _, err := time.Parse(time.RFC3339, s); err == nil {
+		// microsecond precision is BigQuery's upper limit
+		return arrow.FixedWidthTypes.Timestamp_us
+	}
+
+	// fallback
+	return arrow.BinaryTypes.String
+}
+
+func inferArrowSchema(header string, firstRow []string, delimiter string) (*arrow.Schema, error) {
+	cols := strings.Split(header, delimiter)
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("empty header line")
+	}
+
+	// if firstRow is shorter than header, treat missing samples as empty
+	if firstRow == nil {
+		firstRow = make([]string, len(cols))
+	}
+
+	fields := make([]arrow.Field, len(cols))
+	for i, raw := range cols {
+		name := sanitizeBQIdentifier(raw)
+		sample := ""
+		if i < len(firstRow) {
+			sample = firstRow[i]
+		}
+		fields[i] = arrow.Field{
+			Name:     name,
+			Type:     detectArrowType(sample),
+			Nullable: true,
+		}
+	}
+	return arrow.NewSchema(fields, nil), nil
+}
+
+// BigQuery: letters, numbers and underscores, must start with a letter or underscore.
+func sanitizeBQIdentifier(raw string) string {
+	s := strings.TrimSpace(raw)
+	// BigQuery is case-insensitive but case-preserving:
+	// keep original case except for illegal chars.
+	var b strings.Builder
+	for i, r := range s {
+		if unicode.IsLetter(r) || r == '_' || (i > 0 && unicode.IsDigit(r)) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	id := b.String()
+	if id == "" || unicode.IsDigit(rune(id[0])) {
+		id = "_" + id
+	}
+	return id
+}
 // ExecutePartitions executes the current statement and gets the results
 // as a partitioned result set.
 //
@@ -915,6 +1018,17 @@ func (st *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc
 	}
 }
 
+// initIngest uploads a local CSV file to BigQuery.
+//
+// The function
+//   1. opens the file and reads *only* the header line plus the first data row;
+//   2. infers an Arrow schema from that sample (promoting obvious INT64 / FLOAT64 /
+//      BOOL / DATE / TIMESTAMP columns, leaving everything else STRING);
+//   3. converts the Arrow schema to a BigQuery Schema object;
+//   4. rewinds the file handle and executes a load job with the explicit schema.
+//
+// The caller (executeIngest) ignores the job's result set because an ingest
+// operation never returns rows.
 func (st *statement) initIngest(ctx context.Context) error {
 	if st.ingestPath == "" {
 		return adbc.Error{
@@ -923,25 +1037,61 @@ func (st *statement) initIngest(ctx context.Context) error {
 		}
 	}
 
-	// Open file
+	//---------------------------------------------------------------------------
+	// 1.  Open the file and read header + first data row
+	//---------------------------------------------------------------------------
 	file, err := os.Open(st.ingestPath)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
+		return fmt.Errorf("open %q: %w", st.ingestPath, err)
 	}
 	defer file.Close()
 
+	r := bufio.NewReader(file)
+	headerLine, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("read header: %w", err)
+	}
+	headerLine = strings.TrimRight(headerLine, "\r\n")
+
+	firstRowLine, _ := r.ReadString('\n')        // ignore EOF error here
+	firstRowLine = strings.TrimRight(firstRowLine, "\r\n")
+	var firstRow []string
+	if firstRowLine != "" {
+		firstRow = strings.Split(firstRowLine, st.ingestFileDelimiter)
+	}
+
+	// rewind reader for the load job
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind: %w", err)
+	}
+
+	//---------------------------------------------------------------------------
+	// 2.  Sanity-check destination identifiers
+	//---------------------------------------------------------------------------
 	if st.queryConfig.Dst == nil {
-		panic("PANIC: queryConfig.Dst is nil — project_id, dataset_id, table_id likely not set")
+		log.Fatal("queryConfig.Dst is nil — project_id, dataset_id, table_id likely not set")
 	}
 	if st.queryConfig.Dst.ProjectID == "" {
-		panic("PANIC: ProjectID is empty on queryConfig.Dst")
+		log.Fatal("ProjectID is empty on queryConfig.Dst")
 	}
 
-	loadSource := bigquery.NewReaderSource(file)
-	// carry schema over
-	loadSource.AutoDetect = true
-	job := st.queryConfig.Dst.LoaderFrom(loadSource)
+	//---------------------------------------------------------------------------
+	// 3.  Infer Arrow to BigQuery schema
+	//---------------------------------------------------------------------------
+	arrowSchema, err := inferArrowSchema(headerLine, firstRow, st.ingestFileDelimiter)
+	if err != nil {
+		return fmt.Errorf("infer arrow schema: %w", err)
+	}
+	bqSchema, err := arrowSchemaToBigQuery(arrowSchema)
+	if err != nil {
+		return fmt.Errorf("arrow to bq schema: %w", err)
+	}
 
+	//---------------------------------------------------------------------------
+	// 4.  Configure and run the load job with explicit schema
+	//---------------------------------------------------------------------------
+	loadSource := bigquery.NewReaderSource(file)
+	job := st.queryConfig.Dst.LoaderFrom(loadSource)
 	job.WriteDisposition = st.queryConfig.WriteDisposition
 
 	// Set file config
@@ -949,6 +1099,7 @@ func (st *statement) initIngest(ctx context.Context) error {
 	fileCfg.SourceFormat = bigquery.CSV // TODO: parameterize for other files
 	fileCfg.SkipLeadingRows = 1
 	fileCfg.FieldDelimiter = st.ingestFileDelimiter
+	fileCfg.Schema = bqSchema
 
 	handle, err := job.Run(ctx)
 	if err != nil {
@@ -966,6 +1117,8 @@ func (st *statement) initIngest(ctx context.Context) error {
 	return nil
 }
 
+// executeIngest calls initIngest and returns an empty RecordReader so the
+// driver satisfies the ADBC interface even though load jobs have no result set.
 func (st *statement) executeIngest(ctx context.Context) (array.RecordReader, int64, error) {
 	err := st.initIngest(ctx)
 	if err != nil {

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -18,7 +18,6 @@
 package bigquery
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -414,23 +413,6 @@ func (st *statement) query() *bigquery.Query {
 	return query
 }
 
-func listMeta(f arrow.Field, arr arrow.Array) (elemField arrow.Field, listValues arrow.Array, err error) {
-	switch lt := f.Type.(type) {
-	case *arrow.ListType:
-		return lt.ElemField(), arr.(*array.List).ListValues(), nil
-	case *arrow.LargeListType:
-		return lt.ElemField(), arr.(*array.LargeList).ListValues(), nil
-	case *arrow.FixedSizeListType:
-		return lt.ElemField(), arr.(*array.FixedSizeList).ListValues(), nil
-	case *arrow.ListViewType:
-		return lt.ElemField(), arr.(*array.ListView).ListValues(), nil
-	case *arrow.LargeListViewType:
-		return lt.ElemField(), arr.(*array.LargeListView).ListValues(), nil
-	default:
-		return arrow.Field{}, nil, fmt.Errorf("unsupported list type %T", f.Type)
-	}
-}
-
 func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.StandardSQLDataType, error) {
 	// https://cloud.google.com/bigquery/docs/reference/storage#arrow_schema_details
 	// https://cloud.google.com/bigquery/docs/reference/rest/v2/StandardSqlDataType#typekind
@@ -531,127 +513,6 @@ func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.Sta
 			Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", value.DataType().ID()),
 		}
 	}
-}
-
-func arrowFieldToBigQueryField(arrowField arrow.Field) (bigquery.FieldSchema, error) {
-	switch arrowField.Type.ID() {
-	case arrow.BOOL:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.BooleanFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.IntegerFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.FloatFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.BINARY, arrow.BINARY_VIEW, arrow.LARGE_BINARY, arrow.FIXED_SIZE_BINARY:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.BytesFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.STRING, arrow.STRING_VIEW, arrow.LARGE_STRING:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.StringFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.TIMESTAMP:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.TimestampFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.DATE32, arrow.DATE64:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.DateFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.TIME32, arrow.TIME64:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.TimeFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.DECIMAL128:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.NumericFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.DECIMAL256:
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.BigNumericFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
-		elemField := arrowField.Type.(*arrow.ListType).ElemField()
-		elemType, err := arrowFieldToBigQueryField(elemField)
-		if err != nil {
-			return bigquery.FieldSchema{}, err
-		}
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     elemType.Type,
-			Required: !arrowField.Nullable,
-			Repeated: true,
-		}, nil
-	case arrow.STRUCT:
-		// ToDo: implement structs schema generation
-		return bigquery.FieldSchema{
-			Name:     arrowField.Name,
-			Type:     bigquery.RecordFieldType,
-			Required: !arrowField.Nullable,
-		}, nil
-	default:
-		// todo: implement all other types
-		//
-		// - arrow.DURATION
-		//   For arrow.DURATION, I'm not sure which SQL DataType would be a good
-		//   representation for it. `DATETIME` could be a potential one for it,
-		//   if we count from `0000-01-01T00:00:00.000000Z`
-		//
-		// - arrow.INTERVAL_MONTHS
-		// - arrow.INTERVAL_DAY_TIME
-		// - arrow.INTERVAL_MONTH_DAY_NANO
-		//   `DATETIME` could be a potential fit for all interval types, but
-		//   the issue is there's no rules about how many days are in a month.
-		//
-		// - arrow.RUN_END_ENCODED
-		// - arrow.SPARSE_UNION
-		// - arrow.DENSE_UNION
-		// - arrow.DICTIONARY
-		// - arrow.MAP
-		return bigquery.FieldSchema{}, adbc.Error{
-			Code: adbc.StatusNotImplemented,
-			Msg:  fmt.Sprintf("Parameter type %v is not yet implemented for BigQuery driver", arrowField.Type.ID()),
-		}
-	}
-}
-
-// arrowSchemaToBigQuery converts an Arrow schema to a BigQuery schema
-func arrowSchemaToBigQuery(schema *arrow.Schema) (bigquery.Schema, error) {
-	bqSchema := make(bigquery.Schema, len(schema.Fields()))
-	for i, field := range schema.Fields() {
-		bqField, err := arrowFieldToBigQueryField(field)
-		if err != nil {
-			return nil, err
-		}
-		copy := bqField 	// distinct memory
-		bqSchema[i] = &copy
-	}
-	return bqSchema, nil
 }
 
 func arrowValueToQueryParameterValue(field arrow.Field, value arrow.Array, i int) (bigquery.QueryParameter, error) {
@@ -919,89 +780,6 @@ func (st *statement) GetParameterSchema() (*arrow.Schema, error) {
 	}
 }
 
-func detectArrowType(sample string) arrow.DataType {
-	s := strings.TrimSpace(sample)
-	if s == "" {
-		// empty first row → keep as STRING so later NULLs are possible
-		return arrow.BinaryTypes.String
-	}
-
-	// ----- BOOL -----
-	if strings.EqualFold(s, "true") || strings.EqualFold(s, "false") {
-		return arrow.FixedWidthTypes.Boolean
-	}
-
-	// ----- INT64 ----
-	if _, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return arrow.PrimitiveTypes.Int64
-	}
-
-	// ----- FLOAT64 --
-	if _, err := strconv.ParseFloat(s, 64); err == nil {
-		return arrow.PrimitiveTypes.Float64
-	}
-
-	// ----- DATE -----
-	if _, err := time.Parse("2006-01-02", s); err == nil {
-		return arrow.FixedWidthTypes.Date32
-	}
-
-	// ----- TIMESTAMP (RFC 3339) -----
-	if _, err := time.Parse(time.RFC3339, s); err == nil {
-		// microsecond precision is BigQuery's upper limit
-		return arrow.FixedWidthTypes.Timestamp_us
-	}
-
-	// fallback
-	return arrow.BinaryTypes.String
-}
-
-func inferArrowSchema(header string, firstRow []string, delimiter string) (*arrow.Schema, error) {
-	cols := strings.Split(header, delimiter)
-	if len(cols) == 0 {
-		return nil, fmt.Errorf("empty header line")
-	}
-
-	// if firstRow is shorter than header, treat missing samples as empty
-	if firstRow == nil {
-		firstRow = make([]string, len(cols))
-	}
-
-	fields := make([]arrow.Field, len(cols))
-	for i, raw := range cols {
-		name := sanitizeBQIdentifier(raw)
-		sample := ""
-		if i < len(firstRow) {
-			sample = firstRow[i]
-		}
-		fields[i] = arrow.Field{
-			Name:     name,
-			Type:     detectArrowType(sample),
-			Nullable: true,
-		}
-	}
-	return arrow.NewSchema(fields, nil), nil
-}
-
-// BigQuery: letters, numbers and underscores, must start with a letter or underscore.
-func sanitizeBQIdentifier(raw string) string {
-	s := strings.TrimSpace(raw)
-	// BigQuery is case-insensitive but case-preserving:
-	// keep original case except for illegal chars.
-	var b strings.Builder
-	for i, r := range s {
-		if unicode.IsLetter(r) || r == '_' || (i > 0 && unicode.IsDigit(r)) {
-			b.WriteRune(r)
-		} else {
-			b.WriteRune('_')
-		}
-	}
-	id := b.String()
-	if id == "" || unicode.IsDigit(rune(id[0])) {
-		id = "_" + id
-	}
-	return id
-}
 // ExecutePartitions executes the current statement and gets the results
 // as a partitioned result set.
 //
@@ -1046,20 +824,6 @@ func (st *statement) initIngest(ctx context.Context) error {
 	}
 	defer file.Close()
 
-	r := bufio.NewReader(file)
-	headerLine, err := r.ReadString('\n')
-	if err != nil && err != io.EOF {
-		return fmt.Errorf("read header: %w", err)
-	}
-	headerLine = strings.TrimRight(headerLine, "\r\n")
-
-	firstRowLine, _ := r.ReadString('\n')        // ignore EOF error here
-	firstRowLine = strings.TrimRight(firstRowLine, "\r\n")
-	var firstRow []string
-	if firstRowLine != "" {
-		firstRow = strings.Split(firstRowLine, st.ingestFileDelimiter)
-	}
-
 	// rewind reader for the load job
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return fmt.Errorf("rewind: %w", err)
@@ -1074,21 +838,8 @@ func (st *statement) initIngest(ctx context.Context) error {
 	if st.queryConfig.Dst.ProjectID == "" {
 		log.Fatal("ProjectID is empty on queryConfig.Dst")
 	}
-
 	//---------------------------------------------------------------------------
-	// 3.  Infer Arrow to BigQuery schema
-	//---------------------------------------------------------------------------
-	arrowSchema, err := inferArrowSchema(headerLine, firstRow, st.ingestFileDelimiter)
-	if err != nil {
-		return fmt.Errorf("infer arrow schema: %w", err)
-	}
-	bqSchema, err := arrowSchemaToBigQuery(arrowSchema)
-	if err != nil {
-		return fmt.Errorf("arrow to bq schema: %w", err)
-	}
-
-	//---------------------------------------------------------------------------
-	// 4.  Configure and run the load job with explicit schema
+	// 3.  Configure and run the load job with explicit schema
 	//---------------------------------------------------------------------------
 	loadSource := bigquery.NewReaderSource(file)
 	job := st.queryConfig.Dst.LoaderFrom(loadSource)
@@ -1099,8 +850,7 @@ func (st *statement) initIngest(ctx context.Context) error {
 	fileCfg.SourceFormat = bigquery.CSV // TODO: parameterize for other files
 	fileCfg.SkipLeadingRows = 1
 	fileCfg.FieldDelimiter = st.ingestFileDelimiter
-	fileCfg.Schema = bqSchema
-
+	fileCfg.AutoDetect = true
 	handle, err := job.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to start query job: %w", err)


### PR DESCRIPTION
successor of #18 

This works for the test projects in fusion.

But there are some SDK subtleties and alternatives here.

I think we should revisit the drawing board a bit when we can slow down and focus more on what's going on here (as opposed to shipping for Wednesday). I think Colin reached for an API that's an earlier option than the Bigquery QueryParameter type found in later version of the library. 


I tested `jaffle-shop-classic` which includes numbers, strings, booleans, and date/times in their payloads.