### PR TITLE
fix(driver/driver): fix dbt seed with a custom schema

### DIFF
--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -19,6 +19,7 @@ package bigquery
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -57,7 +57,7 @@ const (
 	OptionValueQueryParameterModeNamed      = "adbc.bigquery.sql.query.parameter_mode_named"
 	OptionValueQueryParameterModePositional = "adbc.bigquery.sql.query.parameter_mode_positional"
 
-	OptionStringQueryDestinationTable  = "adbc.bigquery.sql.query.destination_table"
+	OptionStringQueryDestination       = "adbc.bigquery.sql.query.destination"
 	OptionStringQueryDefaultProjectID  = "adbc.bigquery.sql.query.default_project_id"
 	OptionStringQueryDefaultDatasetID  = "adbc.bigquery.sql.query.default_dataset_id"
 	OptionStringQueryCreateDisposition = "adbc.bigquery.sql.query.create_disposition"

--- a/go/adbc/driver/bigquery/driver_test.go
+++ b/go/adbc/driver/bigquery/driver_test.go
@@ -1633,7 +1633,7 @@ func (suite *BigQueryTests) TestStatementExecuteQueryIngest() {
 			defer stmt.Close()
 
 			// Set destination table
-			err = stmt.SetOption(driver.OptionStringQueryDestinationTable, "test_ingest")
+			err = stmt.SetOption(driver.OptionStringQueryDestination, "project.dataset.table")
 			suite.Require().NoError(err)
 
 			// Run setup

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -115,7 +116,7 @@ func (st *statement) GetOption(key string) (string, error) {
 		}
 	case OptionStringQueryParameterMode:
 		return st.parameterMode, nil
-	case OptionStringQueryDestinationTable:
+	case OptionStringQueryDestination:
 		return tableToString(st.queryConfig.Dst), nil
 	case OptionStringQueryDefaultProjectID:
 		return st.queryConfig.DefaultProjectID, nil
@@ -186,11 +187,15 @@ func (st *statement) SetOption(key string, v string) error {
 				Msg:  fmt.Sprintf("Parameter mode for the statement can only be either %s or %s", OptionValueQueryParameterModeNamed, OptionValueQueryParameterModePositional),
 			}
 		}
-	case OptionStringQueryDestinationTable:
-		proj, ds, tbl, err := parseParts(st.cnxn.catalog, st.cnxn.dbSchema, v)
-		if err != nil {
-			return err
+	case OptionStringQueryDestination:
+		parts := strings.Split(v, ".")
+		if len(parts) != 3 {
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("Invalid destination format. Expected format: project_id.dataset_id.table_id, got %s", v),
+			}
 		}
+		proj, ds, tbl := parts[0], parts[1], parts[2]
 		st.queryConfig.Dst = st.cnxn.table(proj, ds, tbl)
 	case OptionStringQueryDefaultProjectID:
 		st.queryConfig.DefaultProjectID = v
@@ -797,11 +802,11 @@ func (st *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc
 // initIngest uploads a local CSV file to BigQuery.
 //
 // The function
-//   1. opens the file and reads *only* the header line plus the first data row;
-//   2. infers an Arrow schema from that sample (promoting obvious INT64 / FLOAT64 /
-//      BOOL / DATE / TIMESTAMP columns, leaving everything else STRING);
-//   3. converts the Arrow schema to a BigQuery Schema object;
-//   4. rewinds the file handle and executes a load job with the explicit schema.
+//  1. opens the file and reads *only* the header line plus the first data row;
+//  2. infers an Arrow schema from that sample (promoting obvious INT64 / FLOAT64 /
+//     BOOL / DATE / TIMESTAMP columns, leaving everything else STRING);
+//  3. converts the Arrow schema to a BigQuery Schema object;
+//  4. rewinds the file handle and executes a load job with the explicit schema.
 //
 // The caller (executeIngest) ignores the job's result set because an ingest
 // operation never returns rows.


### PR DESCRIPTION
`OptionStringQueryDestination` takes a 3 part fully qualified name, since the dataset id may be different from the default for the current relation to be materialized