### PR TITLE
bring back OptionStringQueryDestinationTable

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -66,9 +66,9 @@ type connectionImpl struct {
 	client *bigquery.Client
 }
 
-// Helper for configuration of a connection for use with a job
+// This creates a bigquery.Table associated with the connection's client
 func (c *connectionImpl) table(project, dataset, table string) *bigquery.Table {
-    return c.client.DatasetInProject(project, dataset).Table(table)
+	return c.client.DatasetInProject(project, dataset).Table(table)
 }
 
 func (c *connectionImpl) GetCatalogs(ctx context.Context, catalogFilter *string) ([]string, error) {
@@ -513,9 +513,9 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	}
 	switch c.authType {
 	case OptionValueAuthTypeJSONCredentialFile,
-	    OptionValueAuthTypeJSONCredentialString,
-	    OptionValueAuthTypeUserAuthentication,
-	    OptionValueAuthTypeTemporaryAccessToken:
+		OptionValueAuthTypeJSONCredentialString,
+		OptionValueAuthTypeUserAuthentication,
+		OptionValueAuthTypeTemporaryAccessToken:
 		var credentials option.ClientOption
 
 		switch c.authType {

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -149,18 +149,16 @@ func parseParts(defaultProjectID, defaultDatasetID, value string) (string, strin
 
 // This takes a partially qualified table string in format [project.][.dataset.]table
 // and returns a bigquery.Table object.
-// If project or dataset is not provided, the default project ID and dataset ID are used.
+// If project or dataset is not provided, the default project ID and dataset ID from the statement is used
 // Returns an error if the format is invalid.
-func stringToTable(defaultProjectID, defaultDatasetID, value string) (*bigquery.Table, error) {
+func stringToTable(st *statement, value string) (*bigquery.Table, error) {
+	defaultProjectID := st.cnxn.catalog
+	defaultDatasetID := st.cnxn.dbSchema
 	projectID, datasetID, tableID, err := parseParts(defaultProjectID, defaultDatasetID, value)
 	if err != nil {
 		return nil, err
 	}
-	return &bigquery.Table{
-		ProjectID: projectID,
-		DatasetID: datasetID,
-		TableID:   tableID,
-	}, nil
+	return st.cnxn.table(projectID, datasetID, tableID), nil
 }
 
 func stringToTableCreateDisposition(value string) (bigquery.TableCreateDisposition, error) {

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -57,7 +57,7 @@ const (
 	OptionValueQueryParameterModeNamed      = "adbc.bigquery.sql.query.parameter_mode_named"
 	OptionValueQueryParameterModePositional = "adbc.bigquery.sql.query.parameter_mode_positional"
 
-	OptionStringQueryDestination       = "adbc.bigquery.sql.query.destination"
+	OptionStringQueryDestinationTable  = "adbc.bigquery.sql.query.destination_table"
 	OptionStringQueryDefaultProjectID  = "adbc.bigquery.sql.query.default_project_id"
 	OptionStringQueryDefaultDatasetID  = "adbc.bigquery.sql.query.default_dataset_id"
 	OptionStringQueryCreateDisposition = "adbc.bigquery.sql.query.create_disposition"
@@ -147,6 +147,10 @@ func parseParts(defaultProjectID, defaultDatasetID, value string) (string, strin
 	}
 }
 
+// This takes a partially qualified table string in format [project.][.dataset.]table
+// and returns a bigquery.Table object.
+// If project or dataset is not provided, the default project ID and dataset ID are used.
+// Returns an error if the format is invalid.
 func stringToTable(defaultProjectID, defaultDatasetID, value string) (*bigquery.Table, error) {
 	projectID, datasetID, tableID, err := parseParts(defaultProjectID, defaultDatasetID, value)
 	if err != nil {

--- a/go/adbc/driver/bigquery/driver_test.go
+++ b/go/adbc/driver/bigquery/driver_test.go
@@ -1633,7 +1633,7 @@ func (suite *BigQueryTests) TestStatementExecuteQueryIngest() {
 			defer stmt.Close()
 
 			// Set destination table
-			err = stmt.SetOption(driver.OptionStringQueryDestination, "project.dataset.table")
+			err = stmt.SetOption(driver.OptionStringQueryDestinationTable, "project.dataset.table")
 			suite.Require().NoError(err)
 
 			// Run setup

--- a/go/adbc/driver/bigquery/driver_utils_test.go
+++ b/go/adbc/driver/bigquery/driver_utils_test.go
@@ -80,7 +80,13 @@ func TestStringToTable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := stringToTable(tt.defaultProjectID, tt.defaultDatasetID, tt.input)
+			st := &statement{
+				cnxn: &connectionImpl{
+					catalog:  tt.defaultProjectID,
+					dbSchema: tt.defaultDatasetID,
+				},
+			}
+			result, err := stringToTable(st, tt.input)
 
 			if tt.expectError {
 				if err == nil {

--- a/go/adbc/driver/bigquery/driver_utils_test.go
+++ b/go/adbc/driver/bigquery/driver_utils_test.go
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bigquery
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+)
+
+func TestStringToTable(t *testing.T) {
+	tests := []struct {
+		name             string
+		defaultProjectID string
+		defaultDatasetID string
+		input            string
+		expected         *bigquery.Table
+		expectError      bool
+	}{
+		{
+			name:             "table only",
+			defaultProjectID: "default-project",
+			defaultDatasetID: "default-dataset",
+			input:            "mytable",
+			expected: &bigquery.Table{
+				ProjectID: "default-project",
+				DatasetID: "default-dataset",
+				TableID:   "mytable",
+			},
+			expectError: false,
+		},
+		{
+			name:             "dataset and table",
+			defaultProjectID: "default-project",
+			defaultDatasetID: "default-dataset",
+			input:            "mydataset.mytable",
+			expected: &bigquery.Table{
+				ProjectID: "default-project",
+				DatasetID: "mydataset",
+				TableID:   "mytable",
+			},
+			expectError: false,
+		},
+		{
+			name:             "project, dataset and table",
+			defaultProjectID: "default-project",
+			defaultDatasetID: "default-dataset",
+			input:            "myproject.mydataset.mytable",
+			expected: &bigquery.Table{
+				ProjectID: "myproject",
+				DatasetID: "mydataset",
+				TableID:   "mytable",
+			},
+			expectError: false,
+		},
+		{
+			name:             "too many parts",
+			defaultProjectID: "default-project",
+			defaultDatasetID: "default-dataset",
+			input:            "a.b.c.d",
+			expected:         nil,
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := stringToTable(tt.defaultProjectID, tt.defaultDatasetID, tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result.ProjectID != tt.expected.ProjectID ||
+				result.DatasetID != tt.expected.DatasetID ||
+				result.TableID != tt.expected.TableID {
+				t.Errorf("got %+v, want %+v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -185,7 +185,7 @@ func (st *statement) SetOption(key string, v string) error {
 			}
 		}
 	case OptionStringQueryDestinationTable:
-		val, err := stringToTable(st.cnxn.catalog, st.cnxn.dbSchema, v)
+		val, err := stringToTable(st, v)
 		if err == nil {
 			st.queryConfig.Dst = val
 		} else {

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -116,8 +115,6 @@ func (st *statement) GetOption(key string) (string, error) {
 		}
 	case OptionStringQueryParameterMode:
 		return st.parameterMode, nil
-	case OptionStringQueryDestination:
-		return tableToString(st.queryConfig.Dst), nil
 	case OptionStringQueryDefaultProjectID:
 		return st.queryConfig.DefaultProjectID, nil
 	case OptionStringQueryDefaultDatasetID:
@@ -187,16 +184,13 @@ func (st *statement) SetOption(key string, v string) error {
 				Msg:  fmt.Sprintf("Parameter mode for the statement can only be either %s or %s", OptionValueQueryParameterModeNamed, OptionValueQueryParameterModePositional),
 			}
 		}
-	case OptionStringQueryDestination:
-		parts := strings.Split(v, ".")
-		if len(parts) != 3 {
-			return adbc.Error{
-				Code: adbc.StatusInvalidArgument,
-				Msg:  fmt.Sprintf("Invalid destination format. Expected format: project_id.dataset_id.table_id, got %s", v),
-			}
+	case OptionStringQueryDestinationTable:
+		val, err := stringToTable(st.cnxn.catalog, st.cnxn.dbSchema, v)
+		if err == nil {
+			st.queryConfig.Dst = val
+		} else {
+			return err
 		}
-		proj, ds, tbl := parts[0], parts[1], parts[2]
-		st.queryConfig.Dst = st.cnxn.table(proj, ds, tbl)
 	case OptionStringQueryDefaultProjectID:
 		st.queryConfig.DefaultProjectID = v
 	case OptionStringQueryDefaultDatasetID:


### PR DESCRIPTION
This is a follow up change to address comments here https://github.com/dbt-labs/arrow-adbc/pull/31 mainly https://github.com/dbt-labs/arrow-adbc/pull/31#discussion_r2168886555

Bring back the `OptionStringQueryDestinationTable` then `stringToTable` since it already accepts a partially or fully qualified table name then returns a `bigquery.Table` that can be used to override `queryConfig.Dst`