### PR TITLE
Mp/make makefiles make more

### DIFF
--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO_BUILD=go build
-RM=rm -f
+
+MANAGERS = bigquery databricks flightsql panicdummy snowflake
+
+GO_BUILD := go build
+RM := rm -f
+RMDIR := rmdir
+
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
 else ifeq ($(shell go env GOOS),windows)
@@ -25,19 +30,28 @@ else
 	SUFFIX=dylib
 endif
 
-DRIVERS := \
-	libadbc_driver_bigquery.$(SUFFIX) \
-	libadbc_driver_databricks.$(SUFFIX) \
-	libadbc_driver_flightsql.$(SUFFIX) \
-	libadbc_driver_panicdummy.$(SUFFIX) \
-	libadbc_driver_snowflake.$(SUFFIX)
+# Expand dynamically libadbc_driver_.SUFFIX
+DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
+
+ifeq ($(shell uname), Darwin)
+	SHA256 := shasum -a 256
+else
+	SHA256 := $(shell command -v sha256sum)
+endif
+
+
+# =========
+#  Targets
+# =========
 
 .PHONY: all regenerate
 all: $(DRIVERS)
 
-libadbc_driver_%.$(SUFFIX): %
-	$(GO_BUILD) -tags driverlib -o $@ -buildmode=c-shared -ldflags "-s -w" ./$<
+
+libadbc_driver_%.$(SUFFIX): % ../driver/% ../go.mod ../go.sum
+	$(GO_BUILD) -tags driverlib -o $@ -buildmode=c-shared -ldflags "-s -w" ./$(*)
 	$(RM) $(basename $@).h
+
 
 regenerate:
 	go run gen/main.go -prefix BigQuery -o ./bigquery/ -driver ../driver/bigquery
@@ -47,4 +61,5 @@ regenerate:
 	go run gen/main.go -prefix Snowflake -o ./snowflake/ -driver ../driver/snowflake
 
 clean:
-	$(RM) $(DRIVERS)
+	$(RM) $(DRIVERS) build/*
+	$(RMDIR) build

--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -14,12 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 MANAGERS = bigquery databricks flightsql panicdummy snowflake
 
 GO_BUILD := go build
 RM := rm -f
-RMDIR := rmdir
 
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
@@ -33,13 +31,6 @@ endif
 # Expand dynamically libadbc_driver_.SUFFIX
 DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
 
-ifeq ($(shell uname), Darwin)
-	SHA256 := shasum -a 256
-else
-	SHA256 := $(shell command -v sha256sum)
-endif
-
-
 # =========
 #  Targets
 # =========
@@ -52,7 +43,6 @@ libadbc_driver_%.$(SUFFIX): % ../driver/% ../go.mod ../go.sum
 	$(GO_BUILD) -tags driverlib -o $@ -buildmode=c-shared -ldflags "-s -w" ./$(*)
 	$(RM) $(basename $@).h
 
-
 regenerate:
 	go run gen/main.go -prefix BigQuery -o ./bigquery/ -driver ../driver/bigquery
 	go run gen/main.go -prefix Databricks -o ./databricks/ -driver ../driver/databricks
@@ -61,5 +51,4 @@ regenerate:
 	go run gen/main.go -prefix Snowflake -o ./snowflake/ -driver ../driver/snowflake
 
 clean:
-	$(RM) $(DRIVERS) build/*
-	$(RMDIR) build
+	$(RM) $(DRIVERS)


### PR DESCRIPTION
QoL upgrade for driver development. More intelligent tracking for changes locally! I'm tired of `rm`-ing out of sync library files and surely you are too!

May have missed some paths but we can add additional dirs/files as we continue to work on the repo.

Also the makefile is DRY-ed out for later additions.

## Demo

![demo](https://github.com/user-attachments/assets/8f9ff140-5bac-402a-934e-077e01e2d475)

## Scenarios covered
1. edit already tracked driver files
2. edit `go.mod`
3. edit `../driver/bigquery` files
4. (not shown but works) edit other package like `../driver/databricks` and `../go.sum` --> triggers no rebuild