### PR TITLE
feat(go/adbc/driver/bigquery): Add "adbc.bigquery.sql.location" parameter

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -36,6 +36,7 @@ type databaseImpl struct {
 	refreshToken          string
 	accessTokenEndpoint   string
 	accessTokenServerName string
+	location              string
 	// projectID is the catalog
 	projectID string
 	// datasetID is the schema
@@ -57,6 +58,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		tableID:                d.tableID,
 		catalog:                d.projectID,
 		dbSchema:               d.datasetID,
+		location:               d.location,
 		resultRecordBufferSize: defaultQueryResultBufferSize,
 		prefetchConcurrency:    defaultQueryPrefetchConcurrency,
 	}
@@ -90,6 +92,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.accessToken, nil
 	case OptionStringAuthRefreshToken:
 		return d.refreshToken, nil
+	case OptionStringLocation:
+		return d.location, nil
 	case OptionStringProjectID:
 		return d.projectID, nil
 	case OptionStringDatasetID:
@@ -145,6 +149,8 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.accessTokenEndpoint = value
 	case OptionStringAuthAccessTokenServerName:
 		d.accessTokenServerName = value
+	case OptionStringLocation:
+		d.location = value
 	case OptionStringProjectID:
 		d.projectID = value
 	case OptionStringDatasetID:

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -53,6 +53,8 @@ type connectionImpl struct {
 	accessTokenEndpoint   string
 	accessTokenServerName string
 
+	// the default location to use for all BigQuery requests
+	location string
 	// catalog is the same as the project id in BigQuery
 	catalog string
 	// dbSchema is the same as the dataset id in BigQuery
@@ -572,6 +574,10 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		client, err := bigquery.NewClient(ctx, c.catalog, credentials)
 		if err != nil {
 			return err
+		}
+
+		if c.location != "" {
+			client.Location = c.location
 		}
 
 		err = client.EnableStorageReadClient(ctx, credentials)

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	OptionStringAuthType  = "adbc.bigquery.sql.auth_type"
+	OptionStringLocation  = "adbc.bigquery.sql.location"
 	OptionStringProjectID = "adbc.bigquery.sql.project_id"
 	OptionStringDatasetID = "adbc.bigquery.sql.dataset_id"
 	OptionStringTableID   = "adbc.bigquery.sql.table_id"

--- a/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
+++ b/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
@@ -52,6 +52,9 @@ class DatabaseOptions(enum.Enum):
     AUTH_CLIENT_SECRET = "adbc.bigquery.sql.auth.client_secret"
     AUTH_REFRESH_TOKEN = "adbc.bigquery.sql.auth.refresh_token"
 
+    #: Specify the location to use for bigquery connection.
+    LOCATION = "adbc.bigquery.sql.location"
+
     #: Specify the project ID to use for bigquery connection.
     PROJECT_ID = "adbc.bigquery.sql.project_id"
 


### PR DESCRIPTION
This commit adds a new `adbc.bigquery.sql.location` parameter to the BigQuery ADBC driver.

I piped it through the `databaseImpl`, down to the `connectionImpl` down to the actual BigQuery `Client`.

Since the Python driver links to the Go one, I also made it a possible connection parameter there.

## Testing with fusion

I have the following `profiles.yml`

```yaml
bigquery:
  target: bigquery
  outputs:
    bigquery:
      type: bigquery
      project: '{{ env_var(''BIGQUERY_TEST_DATABASE'') }}'
      schema: '{{ env_var(''BIGQUERY_USER_SCHEMA'') }}'
      keyfile: '{{ env_var(''BIGQUERY_SERVICE_KEY_PATH'') }}'
      method: service-account

bigquery_eu:
  target: bigquery
  outputs:
    bigquery:
      type: bigquery
      location: EU
      project: '{{ env_var(''BIGQUERY_TEST_DATABASE'') }}'
      schema: '{{ env_var(''BIGQUERY_USER_SCHEMA'') }}'
      keyfile: '{{ env_var(''BIGQUERY_SERVICE_KEY_PATH'') }}'
      method: service-account
```

`dbt build --target bigquery` works but `dbt build --target bigquery_eu` breaks because the dataset is not available in the EU instance.

So I assume it all works!

<img width="2556" height="665" alt="image" src="https://github.com/user-attachments/assets/5da75cbc-22d9-49c2-b9b5-493bff6cc5b0" />

