### PR TITLE
fix(go/adbc): Forward SQLSTATE and vendor code

### DIFF
--- a/go/adbc/pkg/_tmpl/driver.go.tmpl
+++ b/go/adbc/pkg/_tmpl/driver.go.tmpl
@@ -83,7 +83,15 @@ func setErr(err *C.struct_AdbcError, format string, vals ...interface{}) {
 		C.{{.Prefix}}errRelease(err)
 	}
 
-	msg := errPrefix + fmt.Sprintf(format, vals...)
+	var msg string
+	if strings.HasPrefix(format, errPrefix) {
+		// If the error message already starts with the prefix, we don't
+		// want to add it again.
+		msg = fmt.Sprintf(format, vals...)
+	} else {
+		// Otherwise, we prepend the prefix to the error message.
+		msg = errPrefix + fmt.Sprintf(format, vals...)
+	}
 	err.message = C.CString(msg)
 	err.release = (*[0]byte)(C.{{.Prefix}}_release_error)
 }
@@ -93,7 +101,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err.sqlstate[i] = C.char(adbcError.SqlState[i])
 	}
 

--- a/go/adbc/pkg/bigquery/driver.go
+++ b/go/adbc/pkg/bigquery/driver.go
@@ -87,7 +87,15 @@ func setErr(err *C.struct_AdbcError, format string, vals ...interface{}) {
 		C.BigQueryerrRelease(err)
 	}
 
-	msg := errPrefix + fmt.Sprintf(format, vals...)
+	var msg string
+	if strings.HasPrefix(format, errPrefix) {
+		// If the error message already starts with the prefix, we don't
+		// want to add it again.
+		msg = fmt.Sprintf(format, vals...)
+	} else {
+		// Otherwise, we prepend the prefix to the error message.
+		msg = errPrefix + fmt.Sprintf(format, vals...)
+	}
 	err.message = C.CString(msg)
 	err.release = (*[0]byte)(C.BigQuery_release_error)
 }
@@ -97,7 +105,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err.sqlstate[i] = C.char(adbcError.SqlState[i])
 	}
 

--- a/go/adbc/pkg/databricks/driver.go
+++ b/go/adbc/pkg/databricks/driver.go
@@ -87,7 +87,15 @@ func setErr(err *C.struct_AdbcError, format string, vals ...interface{}) {
 		C.DatabrickserrRelease(err)
 	}
 
-	msg := errPrefix + fmt.Sprintf(format, vals...)
+	var msg string
+	if strings.HasPrefix(format, errPrefix) {
+		// If the error message already starts with the prefix, we don't
+		// want to add it again.
+		msg = fmt.Sprintf(format, vals...)
+	} else {
+		// Otherwise, we prepend the prefix to the error message.
+		msg = errPrefix + fmt.Sprintf(format, vals...)
+	}
 	err.message = C.CString(msg)
 	err.release = (*[0]byte)(C.Databricks_release_error)
 }
@@ -97,7 +105,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err.sqlstate[i] = C.char(adbcError.SqlState[i])
 	}
 

--- a/go/adbc/pkg/flightsql/driver.go
+++ b/go/adbc/pkg/flightsql/driver.go
@@ -87,7 +87,15 @@ func setErr(err *C.struct_AdbcError, format string, vals ...interface{}) {
 		C.FlightSQLerrRelease(err)
 	}
 
-	msg := errPrefix + fmt.Sprintf(format, vals...)
+	var msg string
+	if strings.HasPrefix(format, errPrefix) {
+		// If the error message already starts with the prefix, we don't
+		// want to add it again.
+		msg = fmt.Sprintf(format, vals...)
+	} else {
+		// Otherwise, we prepend the prefix to the error message.
+		msg = errPrefix + fmt.Sprintf(format, vals...)
+	}
 	err.message = C.CString(msg)
 	err.release = (*[0]byte)(C.FlightSQL_release_error)
 }
@@ -97,7 +105,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err.sqlstate[i] = C.char(adbcError.SqlState[i])
 	}
 

--- a/go/adbc/pkg/panicdummy/driver.go
+++ b/go/adbc/pkg/panicdummy/driver.go
@@ -87,7 +87,15 @@ func setErr(err *C.struct_AdbcError, format string, vals ...interface{}) {
 		C.PanicDummyerrRelease(err)
 	}
 
-	msg := errPrefix + fmt.Sprintf(format, vals...)
+	var msg string
+	if strings.HasPrefix(format, errPrefix) {
+		// If the error message already starts with the prefix, we don't
+		// want to add it again.
+		msg = fmt.Sprintf(format, vals...)
+	} else {
+		// Otherwise, we prepend the prefix to the error message.
+		msg = errPrefix + fmt.Sprintf(format, vals...)
+	}
 	err.message = C.CString(msg)
 	err.release = (*[0]byte)(C.PanicDummy_release_error)
 }
@@ -97,7 +105,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err.sqlstate[i] = C.char(adbcError.SqlState[i])
 	}
 

--- a/go/adbc/pkg/snowflake/driver.go
+++ b/go/adbc/pkg/snowflake/driver.go
@@ -87,7 +87,15 @@ func setErr(err *C.struct_AdbcError, format string, vals ...interface{}) {
 		C.SnowflakeerrRelease(err)
 	}
 
-	msg := errPrefix + fmt.Sprintf(format, vals...)
+	var msg string
+	if strings.HasPrefix(format, errPrefix) {
+		// If the error message already starts with the prefix, we don't
+		// want to add it again.
+		msg = fmt.Sprintf(format, vals...)
+	} else {
+		// Otherwise, we prepend the prefix to the error message.
+		msg = errPrefix + fmt.Sprintf(format, vals...)
+	}
 	err.message = C.CString(msg)
 	err.release = (*[0]byte)(C.Snowflake_release_error)
 }
@@ -97,7 +105,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err.sqlstate[i] = C.char(adbcError.SqlState[i])
 	}
 


### PR DESCRIPTION
Cherry-picking this from the PR I sent upstream. We had most of the changes already in the fork, but some tiny details were added upstream. I'm bringing them here.