### PR TITLE
Add hooks for configuring lease timeouts without disturbing singleton design. Bump gosnowflake.

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
@@ -142,6 +143,13 @@ func init() {
 			}
 		}
 	}
+
+	// hook to override the defaults used in secure_storage_manager.go
+        gosnowflake.ConfigureLeaseOnce(
+		30*time.Second,    // TTL supports SSO
+		90*time.Second,    // Lease Operation Timeout
+	)
+
 
 	// Disable some stray logs
 	// https://github.com/snowflakedb/gosnowflake/pull/1332

--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -145,11 +145,10 @@ func init() {
 	}
 
 	// hook to override the defaults used in secure_storage_manager.go
-        gosnowflake.ConfigureLeaseOnce(
-		30*time.Second,    // TTL supports SSO
-		90*time.Second,    // Lease Operation Timeout
+	gosnowflake.ConfigureLeaseOnce(
+		30*time.Second, // TTL supports SSO
+		90*time.Second, // Lease Operation Timeout
 	)
-
 
 	// Disable some stray logs
 	// https://github.com/snowflakedb/gosnowflake/pull/1332

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.2.0
 	github.com/bluele/gcache v0.0.2
 	github.com/databricks/databricks-sdk-go v0.72.0
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -42,7 +43,7 @@ require (
 	modernc.org/sqlite v1.37.0
 )
 
-replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.14.3
+replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.14.4
 
 require (
 	cloud.google.com/go v0.118.3 // indirect
@@ -77,7 +78,6 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -97,8 +97,8 @@ github.com/databricks/databricks-sdk-go v0.72.0/go.mod h1:xBtjeP9nq+6MgTewZW1Ecb
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dbt-labs/gosnowflake v1.14.3 h1:caoRFpeHYlcspGUtj56pf01kevHAHOOcB8bR9mc0654=
-github.com/dbt-labs/gosnowflake v1.14.3/go.mod h1:TtWJlnADfC9OSxzhYaB3Z416TO4v0vuUALzWFO7Ajyk=
+github.com/dbt-labs/gosnowflake v1.14.4 h1:lWoYsUCrLLr0MZ8PobvjYS9jsRVt4mLvBcKWO/Aaga0=
+github.com/dbt-labs/gosnowflake v1.14.4/go.mod h1:TtWJlnADfC9OSxzhYaB3Z416TO4v0vuUALzWFO7Ajyk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.13.4 h1:zEqyPVyku6IvWCFwux4x9RxkLOMUL+1vC9xUFv5l2/M=


### PR DESCRIPTION
As requested in https://github.com/dbt-labs/gosnowflake/pull/13, we can configure lease timeouts from inside our fork of arrow-adbc.

This is intended to be minimally invasive in light of the singleton secure storage manager design.

Dependency injection was considered but the lift seems enormous and goes against the deliberate choice to stay somewhat aligned with gosnowflake is it today.