### PR TITLE
fix(go/adbc/driver/bigquery): Fix error for repeatable columns when updating column desc

### DIFF
--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -1126,6 +1126,8 @@ func (st *statement) executeUpdateTableColumnsDescription(ctx context.Context) (
 			Name:        field.Name,
 			Type:        field.Type,
 			Description: field.Description,
+			Repeated:    field.Repeated,
+			Required:    field.Required,
 			Schema:      field.Schema, // For nested fields
 		}
 		if description, exists := columnDescriptions[field.Name]; exists {


### PR DESCRIPTION
Fix error when using updating column description on BigQuery for repeatable columns 