### PR TITLE
(fix driver/snowflake) missing query_id in `select` queries

### DIFF
--- a/go/adbc/driver/snowflake/record_reader.go
+++ b/go/adbc/driver/snowflake/record_reader.go
@@ -282,8 +282,14 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 		fields[i] = f
 	}
 
-	meta := sc.Metadata()
-	out := arrow.NewSchema(fields, &meta)
+	meta := sc.Metadata().ToMap()
+	if _, ok := meta[MetadataKeySnowflakeQueryID]; !ok {
+		meta[MetadataKeySnowflakeQueryID] = ld.QueryID()
+	}
+
+	finalMeta := arrow.MetadataFrom(meta)
+	out := arrow.NewSchema(fields, &finalMeta)
+
 	return out, getRecTransformer(out, transformers)
 }
 


### PR DESCRIPTION
This https://github.com/dbt-labs/arrow-adbc/pull/61 didn't cover DQL queries