### PR TITLE
fix(rust/driver_manager): Add workaround to permit cancel() calls that are concurrent to execute() calls

### DIFF
--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -1528,7 +1528,11 @@ impl Statement for ManagedStatement {
             ));
         }
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let mut statement = unsafe {
+            let mutex_ptr = &self.inner.statement as *const Mutex<ffi::FFI_AdbcStatement>
+                as *mut Mutex<ffi::FFI_AdbcStatement>;
+            (*mutex_ptr).get_mut().unwrap_unchecked()
+        };
         let mut error = ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementCancel);
         let status = unsafe { method(statement.deref_mut(), &mut error) };

--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -1528,6 +1528,21 @@ impl Statement for ManagedStatement {
             ));
         }
         let driver = self.ffi_driver();
+        // Workaround before [1] is fixed.
+        // 
+        // Drivers are supposed to handle thread-safety internally.
+        // It's an overkill for the Rust code to always take a lock
+        // to make calls, but it's true that not all drivers handle
+        // thread-safety well. Nevertheless, for cancellation of
+        // long-running statements (a call to `execute` that holds a
+        // lock while running), we have not choice but to make a call
+        // while a lock is held. This happens as a response to user-
+        // -triggered Ctrl+C and in those situation we are more
+        // concerned about actually cancelling statements than shutting
+        // down cleanly (without cancellation errors and even segfaults).
+        // Join the discussion in [1] to improve this situation.
+        //
+        // [1] https://github.com/apache/arrow-adbc/issues/3454
         let mut statement = unsafe {
             let mutex_ptr = &self.inner.statement as *const Mutex<ffi::FFI_AdbcStatement>
                 as *mut Mutex<ffi::FFI_AdbcStatement>;


### PR DESCRIPTION
Related https://github.com/dbt-labs/arrow-adbc/pull/70

Manually tested on a `Snowflake` and  a `Salesforce` projects, both work to cancel a in-progress job

For Snowflake, define a expensive model like below, and let it run, after ctrl-c, the status of this job will become failed due to cancellation.
```
{{ config(materialized='table') }}

-- Simple but expensive: generate rows and do heavy computation
select 
    seq4() as id,
    pow(seq4(), 3) + sqrt(seq4() * 100000) as expensive_calc,
    md5(repeat('expensive_string', seq4()::string)) as hash_value
from table(generator(rowcount => 100000))
```

For Salesforce, `run` the `salesforce_hello_world` project in `fs` repo, in the console, wait till `customers_child__dll` data transform last run status to be `Processing`, after ctrl-c, this job status will become Cancelled. If `ctrc-c` is sent before this stage, it'll just terminate whatever step that is in progress