### PR TITLE
fix(go/adbc/driver/snowflake): Retain case for GetTableSchema field names

### DIFF
--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -490,7 +490,7 @@ func (c *connectionImpl) toArrowField(columnInfo driverbase.ColumnInfo) arrow.Fi
 }
 
 func descToField(name, typ, isnull, primary string, comment sql.NullString) (field arrow.Field, err error) {
-	field.Name = strings.ToLower(name)
+	field.Name = name
 	if isnull == "Y" {
 		field.Nullable = true
 	}


### PR DESCRIPTION
The schema returned by GetTableSchema strips capitalization from field names. This PR retains the original capitalization, since by forcing field names to be lowercase we lose potentially case-sensitive names.