### PR TITLE
feat(go/adbc/driver/bigquery): Add job labels to statement options

### DIFF
--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -63,6 +63,7 @@ const (
 	OptionStringQueryDefaultDatasetID  = "adbc.bigquery.sql.query.default_dataset_id"
 	OptionStringQueryCreateDisposition = "adbc.bigquery.sql.query.create_disposition"
 	OptionStringQueryWriteDisposition  = "adbc.bigquery.sql.query.write_disposition"
+	OptionStringQueryLabels            = "adbc.bigquery.sql.query.labels"
 	OptionBoolQueryDisableQueryCache   = "adbc.bigquery.sql.query.disable_query_cache"
 	OptionBoolDisableFlattenedResults  = "adbc.bigquery.sql.query.disable_flattened_results"
 	OptionBoolQueryAllowLargeResults   = "adbc.bigquery.sql.query.allow_large_results"
@@ -90,7 +91,7 @@ const (
 	OptionJsonUpdateTableColumnsDescription = "adbc.bigquery.table.update_columns_description"
 	OptionJsonAuthorizeViewToDatasets       = "adbc.bigquery.dataset.authorize_view_to_datasets"
 
-		// WithAppDefaultCredentials instructs the driver to authenticate using
+	// WithAppDefaultCredentials instructs the driver to authenticate using
 	// Application Default Credentials (ADC).
 	OptionValueAuthTypeAppDefaultCredentials = "adbc.bigquery.sql.auth_type.app_default_credentials"
 

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -140,6 +140,12 @@ func (st *statement) GetOption(key string) (string, error) {
 		return string(st.queryConfig.CreateDisposition), nil
 	case OptionStringQueryWriteDisposition:
 		return string(st.queryConfig.WriteDisposition), nil
+	case OptionStringQueryLabels:
+		encoded, err := json.Marshal(st.queryConfig.Labels)
+		if err != nil {
+			return "", err
+		}
+		return string(encoded), nil
 	case OptionBoolQueryDisableQueryCache:
 		return strconv.FormatBool(st.queryConfig.DisableQueryCache), nil
 	case OptionBoolDisableFlattenedResults:
@@ -227,6 +233,14 @@ func (st *statement) SetOption(key string, v string) error {
 		val, err := stringToTableWriteDisposition(v)
 		if err == nil {
 			st.queryConfig.WriteDisposition = val
+		} else {
+			return err
+		}
+	case OptionStringQueryLabels:
+		var labels map[string]string
+		err := json.Unmarshal([]byte(v), &labels)
+		if err == nil {
+			st.queryConfig.Labels = labels
 		} else {
 			return err
 		}


### PR DESCRIPTION
Added new `adbc.bigquery.sql.query.labels` option to prepared statements
that can be used to set labels. It accepts a JSON map of labels.
