### PR TITLE
feat(go/driver/athena): add AWS Athena ADBC driver

### DIFF
--- a/go/adbc/driver/athena/connection.go
+++ b/go/adbc/driver/athena/connection.go
@@ -1,0 +1,303 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package athena
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	athenaSDK "github.com/aws/aws-sdk-go-v2/service/athena"
+)
+
+type connectionImpl struct {
+	driverbase.ConnectionImplBase
+
+	athenaClient *athenaSDK.Client
+	db           *databaseImpl
+}
+
+func (c *connectionImpl) Close() error {
+	c.athenaClient = nil
+	c.db = nil
+	return nil
+}
+
+func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
+	return &statementImpl{
+		conn: c,
+	}, nil
+}
+
+// CurrentNamespacer interface implementation
+
+func (c *connectionImpl) GetCurrentCatalog() (string, error) {
+	return c.db.catalog, nil
+}
+
+func (c *connectionImpl) GetCurrentDbSchema() (string, error) {
+	return c.db.schema, nil
+}
+
+func (c *connectionImpl) SetCurrentCatalog(catalog string) error {
+	c.db.catalog = catalog
+	return nil
+}
+
+func (c *connectionImpl) SetCurrentDbSchema(schema string) error {
+	c.db.schema = schema
+	return nil
+}
+
+// TableTypeLister interface implementation
+
+func (c *connectionImpl) ListTableTypes(_ context.Context) ([]string, error) {
+	return []string{"TABLE", "VIEW", "EXTERNAL_TABLE"}, nil
+}
+
+// GetTableSchema uses Athena's GetTableMetadata API to return an Arrow schema.
+func (c *connectionImpl) GetTableSchema(ctx context.Context, catalog *string, dbSchema *string, tableName string) (*arrow.Schema, error) {
+	cat := c.db.catalog
+	if catalog != nil && *catalog != "" {
+		cat = *catalog
+	}
+	sch := c.db.schema
+	if dbSchema != nil && *dbSchema != "" {
+		sch = *dbSchema
+	}
+
+	out, err := c.athenaClient.GetTableMetadata(ctx, &athenaSDK.GetTableMetadataInput{
+		CatalogName:  &cat,
+		DatabaseName: &sch,
+		TableName:    &tableName,
+	})
+	if err != nil {
+		return nil, adbc.Error{
+			Code: adbc.StatusIO,
+			Msg:  fmt.Sprintf("GetTableMetadata failed: %v", err),
+		}
+	}
+
+	fields := make([]arrow.Field, 0, len(out.TableMetadata.Columns))
+	for _, col := range out.TableMetadata.Columns {
+		name := ""
+		if col.Name != nil {
+			name = *col.Name
+		}
+		dt := athenaTypeToArrow(col.Type)
+		fields = append(fields, arrow.Field{Name: name, Type: dt, Nullable: true})
+	}
+
+	return arrow.NewSchema(fields, nil), nil
+}
+
+// GetObjects uses Athena's ListDatabases / ListTableMetadata APIs.
+func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) (array.RecordReader, error) {
+	cat := c.db.catalog
+	if catalog != nil && *catalog != "" {
+		cat = *catalog
+	}
+
+	var catalogs []string
+	if cat != "" {
+		catalogs = []string{cat}
+	} else {
+		listCatInput := &athenaSDK.ListDataCatalogsInput{}
+		paginator := athenaSDK.NewListDataCatalogsPaginator(c.athenaClient, listCatInput)
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, adbc.Error{
+					Code: adbc.StatusIO,
+					Msg:  fmt.Sprintf("ListDataCatalogs failed: %v", err),
+				}
+			}
+			for _, dc := range page.DataCatalogsSummary {
+				if dc.CatalogName != nil {
+					catalogs = append(catalogs, *dc.CatalogName)
+				}
+			}
+		}
+	}
+
+	addCatalogCh := make(chan driverbase.GetObjectsInfo, len(catalogs)+1)
+	errCh := make(chan error, 1)
+
+	if depth == adbc.ObjectDepthCatalogs {
+		for _, name := range catalogs {
+			nameCopy := name
+			addCatalogCh <- driverbase.GetObjectsInfo{CatalogName: driverbase.Nullable(nameCopy)}
+		}
+		close(addCatalogCh)
+		close(errCh)
+		return driverbase.BuildGetObjectsRecordReader(c.Alloc, addCatalogCh, errCh)
+	}
+
+	go func() {
+		defer close(addCatalogCh)
+		for _, catName := range catalogs {
+			info := driverbase.GetObjectsInfo{CatalogName: driverbase.Nullable(catName)}
+
+			schemas, err := c.listSchemas(ctx, catName, dbSchema)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			dbSchemas := make([]driverbase.DBSchemaInfo, 0, len(schemas))
+			for _, schName := range schemas {
+				schInfo := driverbase.DBSchemaInfo{DbSchemaName: driverbase.Nullable(schName)}
+
+				if depth >= adbc.ObjectDepthTables {
+					tables, err := c.listTables(ctx, catName, schName, tableName)
+					if err != nil {
+						errCh <- err
+						return
+					}
+					schInfo.DbSchemaTables = tables
+				}
+
+				dbSchemas = append(dbSchemas, schInfo)
+			}
+			info.CatalogDbSchemas = dbSchemas
+			addCatalogCh <- info
+		}
+	}()
+
+	return driverbase.BuildGetObjectsRecordReader(c.Alloc, addCatalogCh, errCh)
+}
+
+func (c *connectionImpl) listSchemas(ctx context.Context, catalog string, schemaFilter *string) ([]string, error) {
+	input := &athenaSDK.ListDatabasesInput{
+		CatalogName: &catalog,
+	}
+	paginator := athenaSDK.NewListDatabasesPaginator(c.athenaClient, input)
+	var schemas []string
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, adbc.Error{
+				Code: adbc.StatusIO,
+				Msg:  fmt.Sprintf("ListDatabases failed: %v", err),
+			}
+		}
+		for _, db := range page.DatabaseList {
+			if db.Name == nil {
+				continue
+			}
+			if schemaFilter != nil && *schemaFilter != "" && *db.Name != *schemaFilter {
+				continue
+			}
+			schemas = append(schemas, *db.Name)
+		}
+	}
+	return schemas, nil
+}
+
+func (c *connectionImpl) listTables(ctx context.Context, catalog, schema string, tableFilter *string) ([]driverbase.TableInfo, error) {
+	input := &athenaSDK.ListTableMetadataInput{
+		CatalogName:  &catalog,
+		DatabaseName: &schema,
+	}
+	if tableFilter != nil && *tableFilter != "" {
+		input.Expression = tableFilter
+	}
+
+	paginator := athenaSDK.NewListTableMetadataPaginator(c.athenaClient, input)
+	var tables []driverbase.TableInfo
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, adbc.Error{
+				Code: adbc.StatusIO,
+				Msg:  fmt.Sprintf("ListTableMetadata failed: %v", err),
+			}
+		}
+		for _, tbl := range page.TableMetadataList {
+			if tbl.Name == nil {
+				continue
+			}
+			tableType := "TABLE"
+			if tbl.TableType != nil {
+				tableType = *tbl.TableType
+			}
+
+			var cols []driverbase.ColumnInfo
+			for i, col := range tbl.Columns {
+				colName := ""
+				if col.Name != nil {
+					colName = *col.Name
+				}
+				typeName := ""
+				if col.Type != nil {
+					typeName = *col.Type
+				}
+				pos := int32(i + 1)
+				cols = append(cols, driverbase.ColumnInfo{
+					ColumnName:      colName,
+					OrdinalPosition: &pos,
+					XdbcTypeName:    &typeName,
+				})
+			}
+
+			tables = append(tables, driverbase.TableInfo{
+				TableName:    *tbl.Name,
+				TableType:    tableType,
+				TableColumns: cols,
+			})
+		}
+	}
+	return tables, nil
+}
+
+// athenaTypeToArrow converts an Athena column type string to an Arrow DataType.
+func athenaTypeToArrow(t *string) arrow.DataType {
+	if t == nil {
+		return arrow.BinaryTypes.String
+	}
+	switch *t {
+	case "varchar", "string", "char":
+		return arrow.BinaryTypes.String
+	case "bigint":
+		return arrow.PrimitiveTypes.Int64
+	case "integer", "int":
+		return arrow.PrimitiveTypes.Int32
+	case "smallint":
+		return arrow.PrimitiveTypes.Int16
+	case "tinyint":
+		return arrow.PrimitiveTypes.Int8
+	case "double":
+		return arrow.PrimitiveTypes.Float64
+	case "float", "real":
+		return arrow.PrimitiveTypes.Float32
+	case "boolean":
+		return arrow.FixedWidthTypes.Boolean
+	case "date":
+		return arrow.FixedWidthTypes.Date32
+	case "timestamp", "timestamp with time zone":
+		return arrow.FixedWidthTypes.Timestamp_us
+	case "varbinary", "binary":
+		return arrow.BinaryTypes.Binary
+	default:
+		// array, map, row, decimal, json — stringify
+		return arrow.BinaryTypes.String
+	}
+}

--- a/go/adbc/driver/athena/database.go
+++ b/go/adbc/driver/athena/database.go
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package athena
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	athenaSDK "github.com/aws/aws-sdk-go-v2/service/athena"
+)
+
+type databaseImpl struct {
+	driverbase.DatabaseImplBase
+
+	region       string
+	catalog      string
+	schema       string
+	s3StagingDir string
+	workGroup    string
+
+	authType     string
+	accessKeyID  string
+	secretKey    string
+	sessionToken string
+	profileName  string
+}
+
+func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
+	cfg, err := d.buildAWSConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client := athenaSDK.NewFromConfig(cfg)
+
+	conn := &connectionImpl{
+		ConnectionImplBase: driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
+		athenaClient:       client,
+		db:                 d,
+	}
+
+	return driverbase.NewConnectionBuilder(conn).
+		WithCurrentNamespacer(conn).
+		WithTableTypeLister(conn).
+		Connection(), nil
+}
+
+func (d *databaseImpl) buildAWSConfig(ctx context.Context) (aws.Config, error) {
+	var opts []func(*awsconfig.LoadOptions) error
+
+	if d.region != "" {
+		opts = append(opts, awsconfig.WithRegion(d.region))
+	}
+
+	switch d.authType {
+	case AuthTypeAccessKey:
+		if d.accessKeyID == "" {
+			return aws.Config{}, adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("access key ID is required when using auth type '%s'. Set this via '%s'.", AuthTypeAccessKey, OptionAccessKeyID),
+			}
+		}
+		if d.secretKey == "" {
+			return aws.Config{}, adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("secret key is required when using auth type '%s'. Set this via '%s'.", AuthTypeAccessKey, OptionSecretKey),
+			}
+		}
+		opts = append(opts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(d.accessKeyID, d.secretKey, d.sessionToken),
+		))
+	case AuthTypeProfile:
+		if d.profileName == "" {
+			return aws.Config{}, adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("profile name is required when using auth type '%s'. Set this via '%s'.", AuthTypeProfile, OptionProfileName),
+			}
+		}
+		opts = append(opts, awsconfig.WithSharedConfigProfile(d.profileName))
+	case AuthTypeDefault, "":
+		// use default credential chain — no extra opts needed
+	default:
+		return aws.Config{}, adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  fmt.Sprintf("unknown auth type '%s'", d.authType),
+		}
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return aws.Config{}, adbc.Error{
+			Code: adbc.StatusInvalidState,
+			Msg:  fmt.Sprintf("failed to build AWS config: %v", err),
+		}
+	}
+	return cfg, nil
+}
+
+func (d *databaseImpl) GetOption(key string) (string, error) {
+	switch key {
+	case OptionRegion:
+		return d.region, nil
+	case OptionCatalog:
+		return d.catalog, nil
+	case OptionSchema:
+		return d.schema, nil
+	case OptionS3StagingDir:
+		return d.s3StagingDir, nil
+	case OptionWorkGroup:
+		return d.workGroup, nil
+	case OptionAuthType:
+		return d.authType, nil
+	case OptionAccessKeyID:
+		return d.accessKeyID, nil
+	case OptionSecretKey:
+		return d.secretKey, nil
+	case OptionSessionToken:
+		return d.sessionToken, nil
+	case OptionProfileName:
+		return d.profileName, nil
+	default:
+		return d.DatabaseImplBase.GetOption(key)
+	}
+}
+
+func (d *databaseImpl) SetOptions(options map[string]string) error {
+	for k, v := range options {
+		if err := d.SetOption(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *databaseImpl) SetOption(key, value string) error {
+	switch key {
+	case OptionRegion:
+		d.region = value
+	case OptionCatalog:
+		d.catalog = value
+	case OptionSchema:
+		d.schema = value
+	case OptionS3StagingDir:
+		d.s3StagingDir = value
+	case OptionWorkGroup:
+		d.workGroup = value
+	case OptionAuthType:
+		d.authType = value
+	case OptionAccessKeyID:
+		d.accessKeyID = value
+	case OptionSecretKey:
+		d.secretKey = value
+	case OptionSessionToken:
+		d.sessionToken = value
+	case OptionProfileName:
+		d.profileName = value
+	default:
+		return d.DatabaseImplBase.SetOption(key, value)
+	}
+	return nil
+}

--- a/go/adbc/driver/athena/driver.go
+++ b/go/adbc/driver/athena/driver.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package athena is an ADBC Driver Implementation for AWS Athena.
+package athena
+
+import (
+	"context"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+const (
+	// OptionRegion is the AWS region (e.g. "us-east-1").
+	OptionRegion = "athena.region"
+	// OptionCatalog is the Glue catalog / dbt "database".
+	OptionCatalog = "athena.catalog"
+	// OptionSchema is the default Glue database / dbt "schema".
+	OptionSchema = "athena.schema"
+	// OptionS3StagingDir is the S3 output location (s3://bucket/prefix/).
+	OptionS3StagingDir = "athena.s3_staging_dir"
+	// OptionWorkGroup is the Athena workgroup name.
+	OptionWorkGroup = "athena.work_group"
+	// OptionAuthType selects the AWS authentication method.
+	OptionAuthType = "athena.auth_type"
+	// OptionAccessKeyID is the AWS access key ID for static credentials.
+	OptionAccessKeyID = "athena.aws.access_key_id"
+	// OptionSecretKey is the AWS secret access key for static credentials.
+	OptionSecretKey = "athena.aws.secret_access_key"
+	// OptionSessionToken is the optional AWS session token.
+	OptionSessionToken = "athena.aws.session_token"
+	// OptionProfileName is the named AWS profile to use.
+	OptionProfileName = "athena.aws.profile"
+
+	// AuthTypeDefault uses the default AWS credential chain (env vars, instance profile, etc.).
+	AuthTypeDefault = "iam"
+	// AuthTypeAccessKey uses static key/secret credentials.
+	AuthTypeAccessKey = "access_key"
+	// AuthTypeProfile uses a named AWS shared-config profile.
+	AuthTypeProfile = "profile"
+)
+
+type driverImpl struct {
+	driverbase.DriverImplBase
+}
+
+// NewDriver creates a new Athena ADBC driver using the given Arrow allocator.
+func NewDriver(alloc memory.Allocator) adbc.Driver {
+	info := driverbase.DefaultDriverInfo("Athena")
+	return driverbase.NewDriver(&driverImpl{
+		DriverImplBase: driverbase.NewDriverImplBase(info, alloc),
+	})
+}
+
+func (d *driverImpl) NewDatabase(opts map[string]string) (adbc.Database, error) {
+	return d.NewDatabaseWithContext(context.Background(), opts)
+}
+
+func (d *driverImpl) NewDatabaseWithContext(ctx context.Context, opts map[string]string) (adbc.Database, error) {
+	dbBase, err := driverbase.NewDatabaseImplBase(ctx, &d.DriverImplBase)
+	if err != nil {
+		return nil, err
+	}
+
+	db := &databaseImpl{
+		DatabaseImplBase: dbBase,
+		authType:         AuthTypeDefault,
+	}
+
+	if err := db.SetOptions(opts); err != nil {
+		return nil, err
+	}
+
+	return driverbase.NewDatabase(db), nil
+}

--- a/go/adbc/driver/athena/driver_test.go
+++ b/go/adbc/driver/athena/driver_test.go
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package athena_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/driver/athena"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getSetOptions is a helper to cast adbc.Database to adbc.GetSetOptions.
+func getSetOptions(t *testing.T, db adbc.Database) adbc.GetSetOptions {
+	t.Helper()
+	gso, ok := db.(adbc.GetSetOptions)
+	require.True(t, ok, "database does not implement adbc.GetSetOptions")
+	return gso
+}
+
+func TestNewDriver(t *testing.T) {
+	drv := athena.NewDriver(memory.DefaultAllocator)
+	assert.NotNil(t, drv)
+}
+
+func TestNewDatabase_MissingOptions(t *testing.T) {
+	drv := athena.NewDriver(memory.DefaultAllocator)
+
+	// Should succeed even with no options (validation deferred to Open)
+	db, err := drv.NewDatabase(map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+}
+
+func TestNewDatabase_WithOptions(t *testing.T) {
+	drv := athena.NewDriver(memory.DefaultAllocator)
+
+	db, err := drv.NewDatabase(map[string]string{
+		athena.OptionRegion:       "us-east-1",
+		athena.OptionCatalog:      "AwsDataCatalog",
+		athena.OptionSchema:       "default",
+		athena.OptionS3StagingDir: "s3://my-bucket/athena-results/",
+		athena.OptionWorkGroup:    "primary",
+		athena.OptionAuthType:     athena.AuthTypeDefault,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+}
+
+func TestGetSetOption(t *testing.T) {
+	drv := athena.NewDriver(memory.DefaultAllocator)
+
+	db, err := drv.NewDatabase(map[string]string{
+		athena.OptionRegion:  "us-west-2",
+		athena.OptionCatalog: "MyCatalog",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+
+	gso := getSetOptions(t, db)
+
+	region, err := gso.GetOption(athena.OptionRegion)
+	require.NoError(t, err)
+	assert.Equal(t, "us-west-2", region)
+
+	catalog, err := gso.GetOption(athena.OptionCatalog)
+	require.NoError(t, err)
+	assert.Equal(t, "MyCatalog", catalog)
+
+	// Update an option
+	err = gso.SetOption(athena.OptionRegion, "eu-west-1")
+	require.NoError(t, err)
+
+	region, err = gso.GetOption(athena.OptionRegion)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-west-1", region)
+}
+
+func TestAuthTypeAccessKey_MissingKey(t *testing.T) {
+	drv := athena.NewDriver(memory.DefaultAllocator)
+
+	db, err := drv.NewDatabase(map[string]string{
+		athena.OptionRegion:       "us-east-1",
+		athena.OptionS3StagingDir: "s3://bucket/prefix/",
+		athena.OptionAuthType:     athena.AuthTypeAccessKey,
+		// Missing access key ID and secret key
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Open should fail because credentials are incomplete
+	_, err = db.Open(context.Background())
+	require.Error(t, err)
+}
+
+func TestAuthTypeProfile_MissingProfileName(t *testing.T) {
+	drv := athena.NewDriver(memory.DefaultAllocator)
+
+	db, err := drv.NewDatabase(map[string]string{
+		athena.OptionRegion:       "us-east-1",
+		athena.OptionS3StagingDir: "s3://bucket/prefix/",
+		athena.OptionAuthType:     athena.AuthTypeProfile,
+		// Missing profile name
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Open(context.Background())
+	require.Error(t, err)
+}
+
+func TestIntegration(t *testing.T) {
+	if os.Getenv("ADBC_ATHENA_TESTS") == "" {
+		t.Skip("set ADBC_ATHENA_TESTS to run integration tests")
+	}
+
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	s3Dir := os.Getenv("ATHENA_S3_STAGING_DIR")
+	require.NotEmpty(t, s3Dir, "ATHENA_S3_STAGING_DIR must be set for integration tests")
+
+	drv := athena.NewDriver(memory.DefaultAllocator)
+	db, err := drv.NewDatabase(map[string]string{
+		athena.OptionRegion:       region,
+		athena.OptionS3StagingDir: s3Dir,
+		athena.OptionAuthType:     athena.AuthTypeDefault,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	conn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	stmt, err := conn.NewStatement()
+	require.NoError(t, err)
+	defer stmt.Close()
+
+	err = stmt.SetSqlQuery("SELECT 1 AS n")
+	require.NoError(t, err)
+
+	rdr, _, err := stmt.ExecuteQuery(context.Background())
+	require.NoError(t, err)
+	defer rdr.Release()
+
+	assert.True(t, rdr.Next())
+	rec := rdr.Record()
+	assert.EqualValues(t, 1, rec.NumCols())
+}

--- a/go/adbc/driver/athena/record_reader.go
+++ b/go/adbc/driver/athena/record_reader.go
@@ -1,0 +1,300 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package athena
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
+)
+
+// newRecordReader builds an array.RecordReader from Athena rows + column metadata.
+// colInfo comes from ResultSetMetadata.ColumnInfo; rows must have the header already skipped.
+func newRecordReader(alloc memory.Allocator, colInfo []types.ColumnInfo, rows []types.Row) (array.RecordReader, error) {
+	schema := buildSchema(colInfo)
+
+	if len(rows) == 0 {
+		return array.NewRecordReader(schema, nil)
+	}
+
+	batch, err := buildRecordBatch(alloc, schema, colInfo, rows)
+	if err != nil {
+		return nil, err
+	}
+	defer batch.Release()
+
+	return array.NewRecordReader(schema, []arrow.RecordBatch{batch})
+}
+
+// buildSchema converts Athena ColumnInfo slice to an Arrow schema.
+func buildSchema(colInfo []types.ColumnInfo) *arrow.Schema {
+	fields := make([]arrow.Field, len(colInfo))
+	for i, col := range colInfo {
+		name := ""
+		if col.Name != nil {
+			name = *col.Name
+		}
+		fields[i] = arrow.Field{
+			Name:     name,
+			Type:     athenaColumnTypeToArrow(col),
+			Nullable: true,
+		}
+	}
+	return arrow.NewSchema(fields, nil)
+}
+
+// athenaColumnTypeToArrow maps a ColumnInfo's type to an Arrow DataType.
+func athenaColumnTypeToArrow(col types.ColumnInfo) arrow.DataType {
+	if col.Type == nil {
+		return arrow.BinaryTypes.String
+	}
+	return athenaTypeStringToArrow(*col.Type)
+}
+
+// athenaTypeStringToArrow maps an Athena type string to an Arrow DataType.
+func athenaTypeStringToArrow(t string) arrow.DataType {
+	switch t {
+	case "varchar", "string", "char":
+		return arrow.BinaryTypes.String
+	case "bigint":
+		return arrow.PrimitiveTypes.Int64
+	case "integer", "int":
+		return arrow.PrimitiveTypes.Int32
+	case "smallint":
+		return arrow.PrimitiveTypes.Int16
+	case "tinyint":
+		return arrow.PrimitiveTypes.Int8
+	case "double":
+		return arrow.PrimitiveTypes.Float64
+	case "float", "real":
+		return arrow.PrimitiveTypes.Float32
+	case "boolean":
+		return arrow.FixedWidthTypes.Boolean
+	case "date":
+		return arrow.FixedWidthTypes.Date32
+	case "timestamp", "timestamp with time zone":
+		return arrow.FixedWidthTypes.Timestamp_us
+	case "varbinary", "binary":
+		return arrow.BinaryTypes.Binary
+	default:
+		// array, map, row, decimal, json — stringify
+		return arrow.BinaryTypes.String
+	}
+}
+
+// buildRecordBatch converts Athena rows into a single Arrow RecordBatch.
+func buildRecordBatch(alloc memory.Allocator, schema *arrow.Schema, colInfo []types.ColumnInfo, rows []types.Row) (arrow.RecordBatch, error) {
+	bldr := array.NewRecordBuilder(alloc, schema)
+	defer bldr.Release()
+
+	for _, row := range rows {
+		for ci, field := range row.Data {
+			if ci >= len(colInfo) {
+				break
+			}
+			val := ""
+			isNull := field.VarCharValue == nil
+			if !isNull {
+				val = *field.VarCharValue
+			}
+			fb := bldr.Field(ci)
+			if err := appendValue(fb, colInfo[ci], val, isNull); err != nil {
+				return nil, fmt.Errorf("column %d (%s): %w", ci, schema.Field(ci).Name, err)
+			}
+		}
+	}
+
+	return bldr.NewRecord(), nil
+}
+
+// appendValue appends a string-encoded value to the appropriate builder type.
+func appendValue(bldr array.Builder, col types.ColumnInfo, val string, isNull bool) error {
+	if isNull {
+		bldr.AppendNull()
+		return nil
+	}
+
+	colType := ""
+	if col.Type != nil {
+		colType = *col.Type
+	}
+
+	switch colType {
+	case "bigint":
+		v, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Int64Builder).Append(v)
+	case "integer", "int":
+		v, err := strconv.ParseInt(val, 10, 32)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Int32Builder).Append(int32(v))
+	case "smallint":
+		v, err := strconv.ParseInt(val, 10, 16)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Int16Builder).Append(int16(v))
+	case "tinyint":
+		v, err := strconv.ParseInt(val, 10, 8)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Int8Builder).Append(int8(v))
+	case "double":
+		v, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Float64Builder).Append(v)
+	case "float", "real":
+		v, err := strconv.ParseFloat(val, 32)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Float32Builder).Append(float32(v))
+	case "boolean":
+		v, err := strconv.ParseBool(val)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.BooleanBuilder).Append(v)
+	case "date":
+		days, err := parseDateToDays(val)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.Date32Builder).Append(arrow.Date32(days))
+	case "timestamp", "timestamp with time zone":
+		us, err := parseTimestampToMicros(val)
+		if err != nil {
+			return err
+		}
+		bldr.(*array.TimestampBuilder).Append(arrow.Timestamp(us))
+	case "varbinary", "binary":
+		bldr.(*array.BinaryBuilder).Append([]byte(val))
+	default:
+		// varchar, string, char, array, map, row, decimal, json, etc.
+		bldr.(*array.StringBuilder).Append(val)
+	}
+	return nil
+}
+
+// parseDateToDays parses "YYYY-MM-DD" and returns days since Unix epoch (1970-01-01).
+// Uses the civil date algorithm from http://howardhinnant.github.io/date_algorithms.html
+func parseDateToDays(s string) (int32, error) {
+	if len(s) < 10 {
+		return 0, fmt.Errorf("unexpected date format: %q", s)
+	}
+	year, err := strconv.Atoi(s[0:4])
+	if err != nil {
+		return 0, err
+	}
+	month, err := strconv.Atoi(s[5:7])
+	if err != nil {
+		return 0, err
+	}
+	day, err := strconv.Atoi(s[8:10])
+	if err != nil {
+		return 0, err
+	}
+	return civilToDays(year, month, day), nil
+}
+
+// civilToDays converts a Gregorian calendar date to days since Unix epoch.
+// Algorithm: http://howardhinnant.github.io/date_algorithms.html days_from_civil
+func civilToDays(y, m, d int) int32 {
+	if m <= 2 {
+		y--
+		m += 9
+	} else {
+		m -= 3
+	}
+	era := y / 400
+	if y < 0 {
+		era = (y - 399) / 400
+	}
+	yoe := y - era*400
+	doy := (153*m+2)/5 + d - 1
+	doe := yoe*365 + yoe/4 - yoe/100 + doy
+	return int32(era*146097 + doe - 719468)
+}
+
+// parseTimestampToMicros parses an Athena timestamp string to microseconds since Unix epoch.
+// Athena timestamps use the format "YYYY-MM-DD HH:MM:SS.ffffff" (fractional part optional).
+func parseTimestampToMicros(s string) (int64, error) {
+	if len(s) < 19 {
+		return 0, fmt.Errorf("unexpected timestamp format: %q", s)
+	}
+	year, err := strconv.Atoi(s[0:4])
+	if err != nil {
+		return 0, err
+	}
+	month, err := strconv.Atoi(s[5:7])
+	if err != nil {
+		return 0, err
+	}
+	day, err := strconv.Atoi(s[8:10])
+	if err != nil {
+		return 0, err
+	}
+	hour, err := strconv.Atoi(s[11:13])
+	if err != nil {
+		return 0, err
+	}
+	min, err := strconv.Atoi(s[14:16])
+	if err != nil {
+		return 0, err
+	}
+	sec, err := strconv.Atoi(s[17:19])
+	if err != nil {
+		return 0, err
+	}
+
+	var fracMicros int64
+	if len(s) > 20 {
+		frac := s[20:]
+		// pad or truncate to 6 digits
+		for len(frac) < 6 {
+			frac += "0"
+		}
+		if len(frac) > 6 {
+			frac = frac[:6]
+		}
+		fracMicros, err = strconv.ParseInt(frac, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	days := civilToDays(year, month, day)
+	totalMicros := int64(days)*86400*1_000_000 +
+		int64(hour)*3600*1_000_000 +
+		int64(min)*60*1_000_000 +
+		int64(sec)*1_000_000 +
+		fracMicros
+
+	return totalMicros, nil
+}

--- a/go/adbc/driver/athena/statement.go
+++ b/go/adbc/driver/athena/statement.go
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package athena
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	athenaSDK "github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
+)
+
+type statementImpl struct {
+	conn  *connectionImpl
+	query string
+}
+
+func (s *statementImpl) Close() error {
+	if s.conn == nil {
+		return adbc.Error{
+			Msg:  "statement already closed",
+			Code: adbc.StatusInvalidState,
+		}
+	}
+	s.conn = nil
+	return nil
+}
+
+func (s *statementImpl) SetOption(key, val string) error {
+	return adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  fmt.Sprintf("unsupported statement option: %s", key),
+	}
+}
+
+func (s *statementImpl) SetSqlQuery(query string) error {
+	s.query = query
+	return nil
+}
+
+func (s *statementImpl) Prepare(_ context.Context) error {
+	return adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  "Athena does not support prepared statements",
+	}
+}
+
+// ExecuteQuery runs the SQL query on Athena, waits for completion, and returns
+// an array.RecordReader over the results.
+func (s *statementImpl) ExecuteQuery(ctx context.Context) (array.RecordReader, int64, error) {
+	if s.query == "" {
+		return nil, -1, adbc.Error{
+			Code: adbc.StatusInvalidState,
+			Msg:  "no query set",
+		}
+	}
+
+	execID, err := s.startQuery(ctx)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	if err := s.waitForQuery(ctx, execID); err != nil {
+		return nil, -1, err
+	}
+
+	rows, colInfo, err := s.fetchResults(ctx, execID)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	rdr, err := newRecordReader(s.conn.Alloc, colInfo, rows)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	return rdr, -1, nil
+}
+
+// ExecuteUpdate runs a DML statement on Athena and returns -1 (rows affected unknown).
+func (s *statementImpl) ExecuteUpdate(ctx context.Context) (int64, error) {
+	if s.query == "" {
+		return -1, adbc.Error{
+			Code: adbc.StatusInvalidState,
+			Msg:  "no query set",
+		}
+	}
+
+	execID, err := s.startQuery(ctx)
+	if err != nil {
+		return -1, err
+	}
+
+	if err := s.waitForQuery(ctx, execID); err != nil {
+		return -1, err
+	}
+
+	return -1, nil
+}
+
+func (s *statementImpl) startQuery(ctx context.Context) (*string, error) {
+	input := &athenaSDK.StartQueryExecutionInput{
+		QueryString: &s.query,
+		QueryExecutionContext: &types.QueryExecutionContext{
+			Catalog:  nilIfEmpty(s.conn.db.catalog),
+			Database: nilIfEmpty(s.conn.db.schema),
+		},
+		ResultConfiguration: &types.ResultConfiguration{
+			OutputLocation: &s.conn.db.s3StagingDir,
+		},
+	}
+	if s.conn.db.workGroup != "" {
+		input.WorkGroup = &s.conn.db.workGroup
+	}
+
+	out, err := s.conn.athenaClient.StartQueryExecution(ctx, input)
+	if err != nil {
+		return nil, adbc.Error{
+			Code: adbc.StatusIO,
+			Msg:  fmt.Sprintf("StartQueryExecution failed: %v", err),
+		}
+	}
+	return out.QueryExecutionId, nil
+}
+
+func (s *statementImpl) waitForQuery(ctx context.Context, execID *string) error {
+	for {
+		out, err := s.conn.athenaClient.GetQueryExecution(ctx, &athenaSDK.GetQueryExecutionInput{
+			QueryExecutionId: execID,
+		})
+		if err != nil {
+			return adbc.Error{
+				Code: adbc.StatusIO,
+				Msg:  fmt.Sprintf("GetQueryExecution failed: %v", err),
+			}
+		}
+
+		state := out.QueryExecution.Status.State
+		switch state {
+		case types.QueryExecutionStateSucceeded:
+			return nil
+		case types.QueryExecutionStateFailed:
+			reason := ""
+			if out.QueryExecution.Status.StateChangeReason != nil {
+				reason = *out.QueryExecution.Status.StateChangeReason
+			}
+			return adbc.Error{
+				Code: adbc.StatusIO,
+				Msg:  fmt.Sprintf("query failed: %s", reason),
+			}
+		case types.QueryExecutionStateCancelled:
+			return adbc.Error{
+				Code: adbc.StatusCancelled,
+				Msg:  "query was cancelled",
+			}
+		default:
+			// QUEUED or RUNNING — poll again
+			select {
+			case <-ctx.Done():
+				return adbc.Error{
+					Code: adbc.StatusCancelled,
+					Msg:  ctx.Err().Error(),
+				}
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
+	}
+}
+
+func (s *statementImpl) fetchResults(ctx context.Context, execID *string) ([]types.Row, []types.ColumnInfo, error) {
+	input := &athenaSDK.GetQueryResultsInput{
+		QueryExecutionId: execID,
+	}
+
+	var rows []types.Row
+	var colInfo []types.ColumnInfo
+	firstPage := true
+
+	paginator := athenaSDK.NewGetQueryResultsPaginator(s.conn.athenaClient, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, nil, adbc.Error{
+				Code: adbc.StatusIO,
+				Msg:  fmt.Sprintf("GetQueryResults failed: %v", err),
+			}
+		}
+
+		if firstPage {
+			if page.ResultSet != nil && page.ResultSet.ResultSetMetadata != nil {
+				colInfo = page.ResultSet.ResultSetMetadata.ColumnInfo
+			}
+			// The first row of the first page is a header row — skip it.
+			if page.ResultSet != nil && len(page.ResultSet.Rows) > 0 {
+				rows = append(rows, page.ResultSet.Rows[1:]...)
+			}
+			firstPage = false
+		} else {
+			if page.ResultSet != nil {
+				rows = append(rows, page.ResultSet.Rows...)
+			}
+		}
+	}
+
+	return rows, colInfo, nil
+}
+
+func (s *statementImpl) Bind(_ context.Context, _ arrow.RecordBatch) error {
+	return adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  "Bind not implemented for Athena driver",
+	}
+}
+
+func (s *statementImpl) BindStream(_ context.Context, _ array.RecordReader) error {
+	return adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  "BindStream not implemented for Athena driver",
+	}
+}
+
+func (s *statementImpl) GetParameterSchema() (*arrow.Schema, error) {
+	return nil, adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  "parameter schema detection not implemented",
+	}
+}
+
+func (s *statementImpl) SetSubstraitPlan(_ []byte) error {
+	return adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  "Substrait plans not supported",
+	}
+}
+
+func (s *statementImpl) ExecutePartitions(_ context.Context) (*arrow.Schema, adbc.Partitions, int64, error) {
+	return nil, adbc.Partitions{}, -1, adbc.Error{
+		Code: adbc.StatusNotImplemented,
+		Msg:  "partitioned result sets not supported",
+	}
+}
+
+// nilIfEmpty returns nil if s is empty, otherwise a pointer to s.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -46,7 +46,9 @@ require (
 	google.golang.org/api v0.253.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
+	gopkg.in/dnaeon/go-vcr.v4 v4.0.6
 	modernc.org/sqlite v1.39.1
+	resty.dev/v3 v3.0.0-beta.6
 )
 
 require (
@@ -66,8 +68,6 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.36.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
-	gopkg.in/dnaeon/go-vcr.v4 v4.0.6 // indirect
-	resty.dev/v3 v3.0.0-beta.6 // indirect
 )
 
 replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.7
@@ -95,14 +95,15 @@ require (
 	github.com/apache/thrift v0.22.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.38.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.4 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.27.28 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.28 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.27.28
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.28
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/athena v1.44.4
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.18 // indirect

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -87,6 +87,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvK
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.16 h1:mimdLQkIX1zr8GIPY1ZtALdBQGxcASiBd2MOp8m/dMc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.16/go.mod h1:YHk6owoSwrIsok+cAH9PENCOGoH5PU2EllX4vLtSrsY=
+github.com/aws/aws-sdk-go-v2/service/athena v1.44.4 h1:/pKCxCslWWJpiVuYD1cF5xaklegUpG+qfAg1314DnIM=
+github.com/aws/aws-sdk-go-v2/service/athena v1.44.4/go.mod h1:Vn+X6oPpEMNBFAlGGHHNiNc+Tk10F3dPYLbtbED7fIE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.4 h1:KypMCbLPPHEmf9DgMGw51jMj77VfGPAN2Kv4cfhlfgI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.4/go.mod h1:Vz1JQXliGcQktFTN/LN6uGppAIRoLBR2bMvIMP0gOjc=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.18 h1:GckUnpm4EJOAio1c8o25a+b3lVfwVzC9gnSBqiiNmZM=


### PR DESCRIPTION
## Summary
- Adds `go/adbc/driver/athena/` implementing a full ADBC driver for AWS Athena
- Uses AWS SDK v2 (`service/athena`) with async query execution: StartQueryExecution → poll GetQueryExecution → paginate GetQueryResults
- Supports IAM credential chain, static access key, and named AWS profile authentication
- Maps Athena/Presto SQL types to Arrow types in `record_reader.go`
- Implements `GetTableSchema` and `GetObjects` via Glue catalog APIs (`GetTableMetadata`, `ListDatabases`, `ListTableMetadata`)
- Promotes `aws-sdk-go-v2/service/athena`, `config`, and `credentials` from indirect to direct deps in `go.mod`

## Connection options
| Option | Description |
|--------|-------------|
| `athena.region` | AWS region (required) |
| `athena.catalog` | Glue catalog name (maps to dbt `database`) |
| `athena.schema` | Default schema (maps to dbt `schema`) |
| `athena.s3_staging_dir` | S3 URI for query results (required) |
| `athena.work_group` | Athena workgroup (optional, default: `primary`) |
| `athena.auth_type` | `iam` / `access_key` / `profile` |

## Test plan
- [ ] Unit tests pass (`go test ./driver/athena/...`)
- [ ] Integration tests with a real Athena endpoint (set `ADBC_ATHENA_TESTS=1`)
- [ ] `go build` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)