### PR TITLE
feat(go/adbc/driver/bigquery): add reservation option support

### DIFF
--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -503,3 +503,45 @@ func TestBuildField(t *testing.T) {
 		})
 	}
 }
+
+func TestStatementSetGetOptionReservation(t *testing.T) {
+	cnxn := &connectionImpl{}
+	st := &statement{cnxn: cnxn}
+
+	const reservation = "projects/my-project/locations/US/reservations/my-reservation"
+
+	// Initially empty
+	got, err := st.GetOption(OptionStringQueryReservation)
+	if err != nil {
+		t.Fatalf("GetOption returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty reservation by default, got %q", got)
+	}
+
+	// Set the reservation
+	if err := st.SetOption(OptionStringQueryReservation, reservation); err != nil {
+		t.Fatalf("SetOption returned error: %v", err)
+	}
+
+	// Round-trip via GetOption
+	got, err = st.GetOption(OptionStringQueryReservation)
+	if err != nil {
+		t.Fatalf("GetOption returned error: %v", err)
+	}
+	if got != reservation {
+		t.Fatalf("expected %q, got %q", reservation, got)
+	}
+
+	// Clear the reservation
+	if err := st.SetOption(OptionStringQueryReservation, ""); err != nil {
+		t.Fatalf("SetOption(empty) returned error: %v", err)
+	}
+	got, err = st.GetOption(OptionStringQueryReservation)
+	if err != nil {
+		t.Fatalf("GetOption returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty after clear, got %q", got)
+	}
+}

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -86,6 +86,11 @@ const (
 	OptionBoolQueryDryRun              = "adbc.bigquery.sql.query.dry_run"
 	OptionBoolQueryCreateSession       = "adbc.bigquery.sql.query.create_session"
 	OptionIntQueryJobTimeout           = "adbc.bigquery.sql.query.job_timeout"
+	// OptionStringQueryReservation specifies the BigQuery reservation to use for query
+	// execution. The value must be a full reservation resource path of the form
+	// "projects/<project>/locations/<location>/reservations/<reservation>".
+	// When set, the query job is submitted under the specified reservation.
+	OptionStringQueryReservation = "adbc.bigquery.sql.query.reservation"
 
 	OptionIntQueryResultBufferSize    = "adbc.bigquery.sql.query.result_buffer_size"
 	OptionIntQueryPrefetchConcurrency = "adbc.bigquery.sql.query.prefetch_concurrency"

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -215,6 +215,8 @@ func (st *statement) GetOption(key string) (string, error) {
 		return strconv.FormatBool(st.queryConfig.DryRun), nil
 	case OptionBoolQueryCreateSession:
 		return strconv.FormatBool(st.queryConfig.CreateSession), nil
+	case OptionStringQueryReservation:
+		return st.queryConfig.Reservation, nil
 	case OptionBoolQueryLinkFailedJob:
 		return strconv.FormatBool(st.linkFailedJob), nil
 	case OptionBoolUseStorageApiDisabledClient:
@@ -404,6 +406,8 @@ func (st *statement) SetOption(key string, v string) error {
 		} else {
 			return err
 		}
+	case OptionStringQueryReservation:
+		st.queryConfig.Reservation = v
 	case OptionStringIngestPath:
 		st.ingestPath = v
 	case OptionStringIngestFileDelimiter:
@@ -749,7 +753,7 @@ func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.Sta
 		}, nil
 	case arrow.INTERVAL_MONTHS, arrow.INTERVAL_DAY_TIME, arrow.INTERVAL_MONTH_DAY_NANO:
 		// "INTERVAL" is not yet documented in BigQuery docs, but it works in
-		// practice here for our puposes.
+		// practice here for our purposes.
 		return bigquery.StandardSQLDataType{
 			TypeKind: "INTERVAL",
 		}, nil

--- a/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
+++ b/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
@@ -211,6 +211,16 @@ class StatementOptions(enum.Enum):
     #: This deadline cannot be adjusted or removed once the job is created.
     JOB_TIMEOUT = "adbc.bigquery.sql.query.job_timeout"
 
+    #: RESERVATION specifies the BigQuery reservation to use for query execution.
+    #: The value must be a full reservation resource path of the form
+    #: ``projects/<project>/locations/<location>/reservations/<reservation>``.
+    #: When set, the query job is submitted under the specified reservation.
+    #: Set to an empty string to clear and use the project default.
+    #:
+    #: For more information, see:
+    #: https://cloud.google.com/bigquery/docs/reservations-intro
+    RESERVATION = "adbc.bigquery.sql.query.reservation"
+
 
 def connect(
     db_kwargs: typing.Optional[typing.Dict[str, str]] = None,


### PR DESCRIPTION
Contributes to https://github.com/dbt-labs/dbt-core/issues/15486

Add OptionStringQueryReservation ("adbc.bigquery.sql.query.reservation") to route BigQuery query jobs to a specific reservation.

- Add OptionStringQueryReservation constant in driver.go
- Handle in statement SetOption/GetOptionString (maps to QueryConfig.Reservation)
- Unit test covering set/get/clear round-trip