### PR TITLE
feat(go/adbc/driver/bigquery): add external-account (WIF) auth

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -42,6 +42,12 @@ type databaseImpl struct {
 	location              string
 	quotaProject          string
 
+	// External-account (Workload Identity Federation) options.
+	externalAccountAudience         string
+	externalAccountImpersonationURL string
+	externalAccountRequestURL       string
+	externalAccountRequestData      string
+
 	impersonateTargetPrincipal string
 	impersonateDelegates       []string
 	impersonateScopes          []string
@@ -56,27 +62,31 @@ type databaseImpl struct {
 
 func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 	conn := &connectionImpl{
-		ConnectionImplBase:         driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
-		authType:                   d.authType,
-		accessToken:                d.accessToken,
-		credentials:                d.credentials,
-		clientID:                   d.clientID,
-		clientSecret:               d.clientSecret,
-		refreshToken:               d.refreshToken,
-		impersonateTargetPrincipal: d.impersonateTargetPrincipal,
-		impersonateDelegates:       d.impersonateDelegates,
-		impersonateScopes:          d.impersonateScopes,
-		impersonateLifetime:        d.impersonateLifetime,
-		accessTokenEndpoint:        d.accessTokenEndpoint,
-		accessTokenServerName:      d.accessTokenServerName,
-		apiEndpoint:                d.apiEndpoint,
-		tableID:                    d.tableID,
-		catalog:                    d.projectID,
-		dbSchema:                   d.datasetID,
-		location:                   d.location,
-		resultRecordBufferSize:     defaultQueryResultBufferSize,
-		prefetchConcurrency:        defaultQueryPrefetchConcurrency,
-		quotaProject:               d.quotaProject,
+		ConnectionImplBase:              driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
+		authType:                        d.authType,
+		accessToken:                     d.accessToken,
+		credentials:                     d.credentials,
+		clientID:                        d.clientID,
+		clientSecret:                    d.clientSecret,
+		refreshToken:                    d.refreshToken,
+		impersonateTargetPrincipal:      d.impersonateTargetPrincipal,
+		impersonateDelegates:            d.impersonateDelegates,
+		impersonateScopes:               d.impersonateScopes,
+		impersonateLifetime:             d.impersonateLifetime,
+		accessTokenEndpoint:             d.accessTokenEndpoint,
+		accessTokenServerName:           d.accessTokenServerName,
+		apiEndpoint:                     d.apiEndpoint,
+		externalAccountAudience:         d.externalAccountAudience,
+		externalAccountImpersonationURL: d.externalAccountImpersonationURL,
+		externalAccountRequestURL:       d.externalAccountRequestURL,
+		externalAccountRequestData:      d.externalAccountRequestData,
+		tableID:                         d.tableID,
+		catalog:                         d.projectID,
+		dbSchema:                        d.datasetID,
+		location:                        d.location,
+		resultRecordBufferSize:          defaultQueryResultBufferSize,
+		prefetchConcurrency:             defaultQueryPrefetchConcurrency,
+		quotaProject:                    d.quotaProject,
 	}
 
 	err := conn.newClient(ctx)
@@ -110,6 +120,14 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.refreshToken, nil
 	case OptionStringAuthQuotaProject:
 		return d.quotaProject, nil
+	case OptionStringAuthExternalAccountAudience:
+		return d.externalAccountAudience, nil
+	case OptionStringAuthExternalAccountImpersonationURL:
+		return d.externalAccountImpersonationURL, nil
+	case OptionStringAuthExternalAccountRequestURL:
+		return d.externalAccountRequestURL, nil
+	case OptionStringAuthExternalAccountRequestData:
+		return d.externalAccountRequestData, nil
 	case OptionStringAPIEndpoint:
 		return d.apiEndpoint, nil
 	case OptionStringLocation:
@@ -159,6 +177,7 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 			OptionValueAuthTypeJSONCredentialString,
 			OptionValueAuthTypeUserAuthentication,
 			OptionValueAuthTypeAppDefaultCredentials,
+			OptionValueAuthTypeExternalAccount,
 			OptionValueAuthTypeTemporaryAccessToken:
 			d.authType = value
 		default:
@@ -186,6 +205,14 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.accessTokenEndpoint = value
 	case OptionStringAuthAccessTokenServerName:
 		d.accessTokenServerName = value
+	case OptionStringAuthExternalAccountAudience:
+		d.externalAccountAudience = value
+	case OptionStringAuthExternalAccountImpersonationURL:
+		d.externalAccountImpersonationURL = value
+	case OptionStringAuthExternalAccountRequestURL:
+		d.externalAccountRequestURL = value
+	case OptionStringAuthExternalAccountRequestData:
+		d.externalAccountRequestData = value
 	case OptionStringAPIEndpoint:
 		d.apiEndpoint = value
 	case OptionStringLocation:

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -44,6 +44,7 @@ import (
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
 	"github.com/apache/arrow-go/v18/arrow"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google/externalaccount"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -62,6 +63,12 @@ type connectionImpl struct {
 	accessTokenEndpoint   string
 	accessTokenServerName string
 	apiEndpoint           string
+
+	// External-account (Workload Identity Federation) options.
+	externalAccountAudience         string
+	externalAccountImpersonationURL string
+	externalAccountRequestURL       string
+	externalAccountRequestData      string
 
 	quotaProject string
 
@@ -280,6 +287,61 @@ type bigQueryTokenResponse struct {
 	TokenType   string `json:"token_type"`
 }
 
+// idpHTTPClient is shared across all IdP token requests; the timeout guards
+// against a hung identity provider when the caller's context has no deadline.
+var idpHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// idpTokenSupplier implements externalaccount.SubjectTokenSupplier by POSTing
+// request_data to request_url and returning the access_token.
+type idpTokenSupplier struct {
+	requestURL  string
+	requestData string
+}
+
+func (s *idpTokenSupplier) SubjectToken(ctx context.Context, _ externalaccount.SupplierOptions) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.requestURL, strings.NewReader(s.requestData))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := idpHTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", adbc.Error{
+			Code: adbc.StatusIO,
+			Msg:  "identity provider rate-limited the token request (429); reduce concurrency or raise the provider's token rate limit",
+		}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", adbc.Error{
+			Code: adbc.StatusIO,
+			Msg:  fmt.Sprintf("identity provider token request failed with status %d: %s", resp.StatusCode, string(body)),
+		}
+	}
+
+	var tokenResponse bigQueryTokenResponse
+	if err := json.Unmarshal(body, &tokenResponse); err != nil {
+		return "", err
+	}
+	if tokenResponse.AccessToken == "" {
+		return "", adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  "access_token missing from identity provider token response; check the token_endpoint request_url and request_data and that the provider issues an OIDC access token",
+		}
+	}
+	return tokenResponse.AccessToken, nil
+}
+
 // GetCurrentCatalog implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) GetCurrentCatalog() (string, error) {
 	return c.catalog, nil
@@ -495,6 +557,14 @@ func (c *connectionImpl) GetOption(key string) (string, error) {
 		return c.refreshToken, nil
 	case OptionStringAuthQuotaProject:
 		return c.quotaProject, nil
+	case OptionStringAuthExternalAccountAudience:
+		return c.externalAccountAudience, nil
+	case OptionStringAuthExternalAccountImpersonationURL:
+		return c.externalAccountImpersonationURL, nil
+	case OptionStringAuthExternalAccountRequestURL:
+		return c.externalAccountRequestURL, nil
+	case OptionStringAuthExternalAccountRequestData:
+		return c.externalAccountRequestData, nil
 	case OptionStringProjectID:
 		return c.catalog, nil
 	case OptionStringDatasetID:
@@ -531,6 +601,14 @@ func (c *connectionImpl) SetOption(key string, value string) error {
 		c.refreshToken = value
 	case OptionStringAuthQuotaProject:
 		c.quotaProject = value
+	case OptionStringAuthExternalAccountAudience:
+		c.externalAccountAudience = value
+	case OptionStringAuthExternalAccountImpersonationURL:
+		c.externalAccountImpersonationURL = value
+	case OptionStringAuthExternalAccountRequestURL:
+		c.externalAccountRequestURL = value
+	case OptionStringAuthExternalAccountRequestData:
+		c.externalAccountRequestData = value
 	case OptionStringProjectID:
 		c.catalog = value
 	case OptionStringDatasetID:
@@ -634,6 +712,35 @@ func (c *connectionImpl) authOptions(ctx context.Context) ([]option.ClientOption
 				TokenType:   "Bearer",
 			}),
 		))
+	case OptionValueAuthTypeExternalAccount:
+		if c.externalAccountAudience == "" {
+			return nil, adbc.Error{Code: adbc.StatusInvalidArgument, Msg: fmt.Sprintf("The `%s` parameter is empty", OptionStringAuthExternalAccountAudience)}
+		}
+		if c.externalAccountRequestURL == "" {
+			return nil, adbc.Error{Code: adbc.StatusInvalidArgument, Msg: fmt.Sprintf("The `%s` parameter is empty", OptionStringAuthExternalAccountRequestURL)}
+		}
+		if c.externalAccountRequestData == "" {
+			return nil, adbc.Error{Code: adbc.StatusInvalidArgument, Msg: fmt.Sprintf("The `%s` parameter is empty", OptionStringAuthExternalAccountRequestData)}
+		}
+		cfg := externalaccount.Config{
+			Audience:                       c.externalAccountAudience,
+			SubjectTokenType:               DefaultSubjectTokenType,
+			TokenURL:                       DefaultSTSTokenURL,
+			ServiceAccountImpersonationURL: c.externalAccountImpersonationURL,
+			Scopes:                         c.impersonateScopes,
+			SubjectTokenSupplier: &idpTokenSupplier{
+				requestURL:  c.externalAccountRequestURL,
+				requestData: c.externalAccountRequestData,
+			},
+		}
+		ts, err := externalaccount.NewTokenSource(ctx, cfg)
+		if err != nil {
+			return nil, adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("failed to create external-account token source: %s", err.Error()),
+			}
+		}
+		authOptions = append(authOptions, option.WithTokenSource(ts))
 	case OptionValueAuthTypeAppDefaultCredentials, OptionValueAuthTypeDefault, "":
 		// Use Application Default Credentials (default behavior)
 		// No additional options needed - ADC is used by default

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -49,6 +49,7 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
+	"resty.dev/v3"
 )
 
 type connectionImpl struct {
@@ -287,9 +288,29 @@ type bigQueryTokenResponse struct {
 	TokenType   string `json:"token_type"`
 }
 
-// idpHTTPClient is shared across all IdP token requests; the timeout guards
-// against a hung identity provider when the caller's context has no deadline.
-var idpHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// oauthErrorResponse is the OAuth 2.0 error body an IdP returns on a rejected token request.
+type oauthErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+const (
+	idpMaxRetries     = 5
+	idpRetryWaitMin   = 500 * time.Millisecond
+	idpRetryWaitMax   = 8 * time.Second
+	idpRequestTimeout = 30 * time.Second
+)
+
+// idpHTTPClient is shared across all IdP token requests. Retries use resty's
+// default capped exponential backoff with jitter. SetAllowNonIdempotentRetry is
+// required because the token request is a POST (resty skips POST retries by
+// default), and re-requesting a token is safe.
+var idpHTTPClient = resty.New().
+	SetTimeout(idpRequestTimeout).
+	SetRetryCount(idpMaxRetries).
+	SetRetryWaitTime(idpRetryWaitMin).
+	SetRetryMaxWaitTime(idpRetryWaitMax).
+	SetAllowNonIdempotentRetry(true)
 
 // idpTokenSupplier implements externalaccount.SubjectTokenSupplier by POSTing
 // request_data to request_url and returning the access_token.
@@ -299,39 +320,56 @@ type idpTokenSupplier struct {
 }
 
 func (s *idpTokenSupplier) SubjectToken(ctx context.Context, _ externalaccount.SupplierOptions) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.requestURL, strings.NewReader(s.requestData))
+	resp, err := idpHTTPClient.R().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetBody(s.requestData).
+		Post(s.requestURL)
 	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := idpHTTPClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
 		return "", adbc.Error{
 			Code: adbc.StatusIO,
-			Msg:  "identity provider rate-limited the token request (429); reduce concurrency or raise the provider's token rate limit",
+			Msg:  fmt.Sprintf("network error communicating with identity provider: %v", err),
 		}
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	body := resp.Bytes()
+
+	if resp.StatusCode() == http.StatusTooManyRequests {
 		return "", adbc.Error{
 			Code: adbc.StatusIO,
-			Msg:  fmt.Sprintf("identity provider token request failed with status %d: %s", resp.StatusCode, string(body)),
+			Msg:  "identity provider is rate-limiting token requests (HTTP 429); reduce concurrency or raise the provider's token rate limit",
+		}
+	}
+	if !resp.IsSuccess() {
+		// Prefer the standard OAuth 2.0 error body; fall back to a truncated raw body.
+		var oauthErr oauthErrorResponse
+		if json.Unmarshal(body, &oauthErr) == nil && oauthErr.Error != "" {
+			desc := oauthErr.ErrorDescription
+			if desc == "" {
+				desc = "no description provided"
+			}
+			return "", adbc.Error{
+				Code: adbc.StatusIO,
+				Msg:  fmt.Sprintf("identity provider rejected the token request (HTTP %d): %s - %s", resp.StatusCode(), oauthErr.Error, desc),
+			}
+		}
+		// Cap the raw body so a large HTML error page doesn't flood the message.
+		raw := string(body)
+		if len(raw) > 256 {
+			raw = raw[:253] + "..."
+		}
+		return "", adbc.Error{
+			Code: adbc.StatusIO,
+			Msg:  fmt.Sprintf("identity provider token request failed (HTTP %d): %s", resp.StatusCode(), raw),
 		}
 	}
 
 	var tokenResponse bigQueryTokenResponse
 	if err := json.Unmarshal(body, &tokenResponse); err != nil {
-		return "", err
+		return "", adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  fmt.Sprintf("could not parse identity provider token response as JSON (%v); the token_endpoint request_url may be returning an HTML proxy or error page instead of a token", err),
+		}
 	}
 	if tokenResponse.AccessToken == "" {
 		return "", adbc.Error{

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -319,6 +319,9 @@ type idpTokenSupplier struct {
 	requestData string
 }
 
+// SubjectToken implements externalaccount.SubjectTokenSupplier and is invoked by
+// the externalaccount token source to fetch the IdP subject token.
+// See https://pkg.go.dev/golang.org/x/oauth2/google/externalaccount#SubjectTokenSupplier
 func (s *idpTokenSupplier) SubjectToken(ctx context.Context, _ externalaccount.SupplierOptions) (string, error) {
 	resp, err := idpHTTPClient.R().
 		SetContext(ctx).

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -220,29 +221,91 @@ func TestExternalAccount_MissingFields(t *testing.T) {
 }
 
 func TestIdpTokenSupplier_SubjectToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
-			t.Errorf("unexpected Content-Type: %s", got)
-		}
-		body, _ := io.ReadAll(r.Body)
-		if string(body) != "grant_type=client_credentials&scope=s" {
-			t.Errorf("request body not sent verbatim: %q", string(body))
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"tok-123","expires_in":3600}`))
-	}))
-	defer srv.Close()
+	const reqData = "grant_type=client_credentials&scope=s"
 
-	s := &idpTokenSupplier{requestURL: srv.URL, requestData: "grant_type=client_credentials&scope=s"}
-	tok, err := s.SubjectToken(context.Background(), externalaccount.SupplierOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	cases := []struct {
+		name      string
+		handler   func(w http.ResponseWriter, r *http.Request, attempt int32)
+		wantToken string
+		wantErr   string // expected error substring; empty means success
+		wantCalls int32  // 0 means don't assert
+	}{
+		{
+			name: "returns token on success",
+			handler: func(w http.ResponseWriter, r *http.Request, _ int32) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+					t.Errorf("unexpected Content-Type: %s", got)
+				}
+				if body, _ := io.ReadAll(r.Body); string(body) != reqData {
+					t.Errorf("request body was modified before sending: %q", string(body))
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"tok-123","expires_in":3600}`))
+			},
+			wantToken: "tok-123",
+			wantCalls: 1,
+		},
+		{
+			name: "retries on 500 then succeeds",
+			handler: func(w http.ResponseWriter, r *http.Request, attempt int32) {
+				if attempt == 1 {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"tok-after-retry"}`))
+			},
+			wantToken: "tok-after-retry",
+			wantCalls: 2,
+		},
+		{
+			name: "no retry on 4xx, surfaces oauth error",
+			handler: func(w http.ResponseWriter, r *http.Request, _ int32) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"bad secret"}`))
+			},
+			wantErr:   "invalid_client",
+			wantCalls: 1,
+		},
+		{
+			name: "non-json body reports parse error",
+			handler: func(w http.ResponseWriter, r *http.Request, _ int32) {
+				w.Header().Set("Content-Type", "text/html")
+				_, _ = w.Write([]byte("<html>proxy login page</html>"))
+			},
+			wantErr: "as JSON",
+		},
 	}
-	if tok != "tok-123" {
-		t.Fatalf("expected tok-123, got %q", tok)
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tt.handler(w, r, atomic.AddInt32(&calls, 1))
+			}))
+			defer srv.Close()
+
+			s := &idpTokenSupplier{requestURL: srv.URL, requestData: reqData}
+			tok, err := s.SubjectToken(context.Background(), externalaccount.SupplierOptions{})
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+			if tok != tt.wantToken {
+				t.Fatalf("expected token %q, got %q", tt.wantToken, tok)
+			}
+			if tt.wantCalls != 0 && atomic.LoadInt32(&calls) != tt.wantCalls {
+				t.Fatalf("expected %d call(s), got %d", tt.wantCalls, atomic.LoadInt32(&calls))
+			}
+		})
 	}
 }
 

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -19,10 +19,14 @@ package bigquery
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
+	"golang.org/x/oauth2/google/externalaccount"
 )
 
 func TestDatabaseAPIEndpointOption(t *testing.T) {
@@ -147,6 +151,98 @@ func TestTemporaryAccessToken_MissingToken(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "adbc.bigquery.sql.auth.access_token") {
 		t.Errorf("Expected error message to mention missing access token, got: %v", err)
+	}
+}
+
+// --- External-account (Workload Identity Federation) -----------------------
+
+const testWIFAudience = "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov"
+
+func TestExternalAccountAuthTypeAccepted(t *testing.T) {
+	db := &databaseImpl{}
+	if err := db.SetOption(OptionStringAuthType, OptionValueAuthTypeExternalAccount); err != nil {
+		t.Fatalf("external_account auth type should be accepted: %v", err)
+	}
+	if err := db.SetOption(OptionStringAuthExternalAccountRequestData, "grant_type=client_credentials"); err != nil {
+		t.Fatalf("SetOption request_data: %v", err)
+	}
+	if got, _ := db.GetOption(OptionStringAuthExternalAccountRequestData); got != "grant_type=client_credentials" {
+		t.Errorf("request_data should round-trip, got %q", got)
+	}
+}
+
+func TestExternalAccount_AuthOptions_Valid(t *testing.T) {
+	conn := &connectionImpl{
+		authType:                   OptionValueAuthTypeExternalAccount,
+		catalog:                    "test-project",
+		dbSchema:                   "test-dataset",
+		externalAccountAudience:    testWIFAudience,
+		externalAccountRequestURL:  "https://idp.example.com/oauth2/v1/token",
+		externalAccountRequestData: "grant_type=client_credentials&client_id=abc&client_secret=secret&scope=s",
+	}
+	opts, err := conn.authOptions(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error building external-account options, got: %v", err)
+	}
+	if len(opts) == 0 {
+		t.Fatal("expected at least one client option (the token source)")
+	}
+}
+
+func TestExternalAccount_MissingFields(t *testing.T) {
+	base := func() *connectionImpl {
+		return &connectionImpl{
+			authType:                   OptionValueAuthTypeExternalAccount,
+			externalAccountAudience:    testWIFAudience,
+			externalAccountRequestURL:  "https://idp/token",
+			externalAccountRequestData: "grant_type=client_credentials",
+		}
+	}
+	cases := []struct {
+		name   string
+		mutate func(*connectionImpl)
+		want   string
+	}{
+		{"audience", func(c *connectionImpl) { c.externalAccountAudience = "" }, OptionStringAuthExternalAccountAudience},
+		{"request_url", func(c *connectionImpl) { c.externalAccountRequestURL = "" }, OptionStringAuthExternalAccountRequestURL},
+		{"request_data", func(c *connectionImpl) { c.externalAccountRequestData = "" }, OptionStringAuthExternalAccountRequestData},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := base()
+			tt.mutate(conn)
+			_, err := conn.authOptions(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error mentioning %q, got: %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestIdpTokenSupplier_SubjectToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("unexpected Content-Type: %s", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "grant_type=client_credentials&scope=s" {
+			t.Errorf("request body not sent verbatim: %q", string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok-123","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	s := &idpTokenSupplier{requestURL: srv.URL, requestData: "grant_type=client_credentials&scope=s"}
+	tok, err := s.SubjectToken(context.Background(), externalaccount.SupplierOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "tok-123" {
+		t.Fatalf("expected tok-123, got %q", tok)
 	}
 }
 

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -30,12 +30,12 @@ import (
 )
 
 const (
-	OptionStringAuthType  = "adbc.bigquery.sql.auth_type"
+	OptionStringAuthType    = "adbc.bigquery.sql.auth_type"
 	OptionStringAPIEndpoint = "adbc.bigquery.sql.api_endpoint"
-	OptionStringLocation  = "adbc.bigquery.sql.location"
-	OptionStringProjectID = "adbc.bigquery.sql.project_id"
-	OptionStringDatasetID = "adbc.bigquery.sql.dataset_id"
-	OptionStringTableID   = "adbc.bigquery.sql.table_id"
+	OptionStringLocation    = "adbc.bigquery.sql.location"
+	OptionStringProjectID   = "adbc.bigquery.sql.project_id"
+	OptionStringDatasetID   = "adbc.bigquery.sql.dataset_id"
+	OptionStringTableID     = "adbc.bigquery.sql.table_id"
 
 	OptionValueAuthTypeDefault = "adbc.bigquery.sql.auth_type.auth_bigquery"
 
@@ -53,6 +53,15 @@ const (
 	OptionStringAuthRefreshToken          = "adbc.bigquery.sql.auth.refresh_token"
 	OptionStringAuthAccessTokenEndpoint   = "adbc.bigquery.sql.auth.access_token_endpoint"
 	OptionStringAuthAccessTokenServerName = "adbc.bigquery.sql.auth.access_token_server_name"
+
+	// External-account (Workload Identity Federation): the subject token is
+	// obtained from an external OAuth2 IdP via the client-credentials grant and
+	// exchanged at Google STS.
+	OptionValueAuthTypeExternalAccount              = "adbc.bigquery.sql.auth_type.external_account"
+	OptionStringAuthExternalAccountAudience         = "adbc.bigquery.sql.auth.external_account.audience"
+	OptionStringAuthExternalAccountImpersonationURL = "adbc.bigquery.sql.auth.external_account.impersonation_url"
+	OptionStringAuthExternalAccountRequestURL       = "adbc.bigquery.sql.auth.external_account.request_url"
+	OptionStringAuthExternalAccountRequestData      = "adbc.bigquery.sql.auth.external_account.request_data"
 
 	// OptionStringQueryParameterMode specifies if the query uses positional syntax ("?")
 	// or the named syntax ("@p"). It is illegal to mix positional and named syntax.
@@ -91,6 +100,10 @@ const (
 
 	DefaultAccessTokenEndpoint   = "https://accounts.google.com/o/oauth2/token"
 	DefaultAccessTokenServerName = "google.com"
+
+	// Google STS endpoint and default subject-token type for external-account.
+	DefaultSTSTokenURL      = "https://sts.googleapis.com/v1/token"
+	DefaultSubjectTokenType = "urn:ietf:params:oauth:token-type:jwt"
 
 	OptionStringIngestFileDelimiter = "adbc.bigquery.ingest.csv_delimiter"
 	OptionStringIngestPath          = "adbc.bigquery.ingest.csv_filepath"


### PR DESCRIPTION
## Summary

This adds Workload Identity Federation (WIF) as an authentication option for the BigQuery driver. With WIF, a workload authenticates through an external identity provider (Microsoft Entra, in the dbt setup) and Google grants BigQuery access based on that.

## How it works

When a profile uses this method, the driver:

1. asks the identity provider (e.g. Entra) for a token, by sending the sign-in request the user put in their profile;
2. trades that token with Google for a short-lived Google access token;
3. optionally "borrows" a service account's identity (impersonation), if the profile points at one;

then uses the resulting token to run BigQuery jobs.

It reads four new settings from the profile: the workload pool/provider path, the provider's token URL, the request body to send it, and an optional service-account impersonation URL.


## Testing

- Go unit tests.
 
<img width="794" height="375" alt="image" src="https://github.com/user-attachments/assets/62296701-e000-4bbb-912f-deba7f6c33ba" />

- Manual `dbt run` against BigQuery via Entra WIF, driven through dbt-labs/fs#10486.

## Dependency

Paired with dbt-labs/fs#10486 (the dbt side that sets these options).
