### PR TITLE
fix(driver/databricks): serialize pool init to prevent OAuth port race

### DIFF
--- a/go/adbc/driver/databricks/database.go
+++ b/go/adbc/driver/databricks/database.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"crypto/tls"
@@ -48,8 +49,9 @@ type databaseImpl struct {
 	driverbase.DatabaseImplBase
 
 	// Connection Pool
+	mu           sync.Mutex
 	db           *sql.DB
-	needsRefresh bool // Whether we need to re-initialize
+	needsRefresh bool
 
 	// Connection parameters
 	serverHostname string
@@ -237,30 +239,34 @@ func (d *databaseImpl) initializeConnectionPool(ctx context.Context) (*sql.DB, e
 	return db, nil
 }
 
-func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
-	// Re-initialize the connection pool and settings if anything
-	// has changed, or we have not initialized yet
-	if d.needsRefresh || d.db == nil {
-		db, err := d.initializeConnectionPool(ctx)
+func (d *databaseImpl) getOrCreatePool(ctx context.Context) (*sql.DB, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-		if err != nil {
-			return nil, err
-		}
-
-		// Close the existing connection pool
-		if d.db != nil {
-			err = d.db.Close()
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		d.db = db
-		d.needsRefresh = false
+	if d.db != nil && !d.needsRefresh {
+		return d.db, nil
 	}
 
-	c, err := d.db.Conn(ctx)
+	db, err := d.initializeConnectionPool(ctx)
+	if err != nil {
+		return nil, err
+	}
 
+	if d.db != nil {
+		_ = d.db.Close()
+	}
+	d.db = db
+	d.needsRefresh = false
+	return d.db, nil
+}
+
+func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
+	db, err := d.getOrCreatePool(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,11 +287,15 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 }
 
 func (d *databaseImpl) Close() error {
-	defer func() {
-		d.needsRefresh = true
-		d.db = nil
-	}()
-	return d.db.Close()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.db == nil {
+		return nil
+	}
+	err := d.db.Close()
+	d.db = nil
+	return err
 }
 
 func (d *databaseImpl) GetOption(key string) (string, error) {
@@ -352,11 +362,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 }
 
 func (d *databaseImpl) SetOptions(options map[string]string) error {
-	// We need to re-initialize the db/connection pool if options change
-	d.needsRefresh = true
 	for k, v := range options {
-		err := d.SetOption(k, v)
-		if err != nil {
+		if err := d.SetOption(k, v); err != nil {
 			return err
 		}
 	}
@@ -364,7 +371,6 @@ func (d *databaseImpl) SetOptions(options map[string]string) error {
 }
 
 func (d *databaseImpl) SetOption(key, value string) error {
-	// We need to re-initialize the db/connection pool if options change
 	d.needsRefresh = true
 	switch key {
 	case OptionAuthType:

--- a/go/adbc/driver/databricks/database_test.go
+++ b/go/adbc/driver/databricks/database_test.go
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package databricks
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestDatabase(t *testing.T) *databaseImpl {
+	t.Helper()
+	info := driverbase.DefaultDriverInfo("Databricks")
+	drvBase := driverbase.NewDriverImplBase(info, memory.DefaultAllocator)
+	dbBase, err := driverbase.NewDatabaseImplBase(context.Background(), &drvBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &databaseImpl{
+		DatabaseImplBase: dbBase,
+		serverHostname:   "test.cloud.databricks.com",
+		httpPath:         "/sql/1.0/warehouses/test",
+		accessToken:      "test-token",
+		authType:         OptionValueAuthTypePAT,
+		port:             443,
+	}
+}
+
+// TestConcurrentOpen verifies that concurrent Open() calls on the same
+// databaseImpl do not race on connection pool initialization.
+// This reproduces the scenario from dbt-core#13387 where multiple
+// goroutines calling Open() simultaneously could both attempt to start
+// the OAuth listener on the same port.
+//
+// Run with: go test -race -run TestConcurrentOpen
+func TestConcurrentOpen(t *testing.T) {
+	db := newTestDatabase(t)
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	errs := make([]error, goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			_, errs[i] = db.Open(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.Error(t, err, "goroutine %d should fail (no real server)", i)
+	}
+}

--- a/go/adbc/driver/databricks/ipc_reader_test.go
+++ b/go/adbc/driver/databricks/ipc_reader_test.go
@@ -130,7 +130,7 @@ func TestIPCReaderAdapter(t *testing.T) {
 
 	// Test the IPC reader adapter
 	ctx := context.Background()
-	reader, err := newIPCReaderAdapter(ctx, mockRows)
+	reader, err := newIPCReaderAdapter(ctx, mockRows, "test-query-id")
 	require.NoError(t, err)
 	defer reader.Release()
 
@@ -227,7 +227,7 @@ func TestIPCReaderAdapterMultipleStreams(t *testing.T) {
 
 	// Test the adapter
 	ctx := context.Background()
-	reader, err := newIPCReaderAdapter(ctx, mockRows)
+	reader, err := newIPCReaderAdapter(ctx, mockRows, "test-query-id")
 	require.NoError(t, err)
 	defer reader.Release()
 


### PR DESCRIPTION
## Summary
- Concurrent `Open()` calls no longer race on pool init (duplicate OAuth listeners on port 8020)

Fixes dbt-labs/dbt-core#13387

🤖 Generated with [Claude Code](https://claude.com/claude-code)