### PR TITLE
fix(bigquery): honor proxy env vars (incl. NO_PROXY) in access-token transport

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -43,6 +43,7 @@ import (
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal"
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
 	"github.com/apache/arrow-go/v18/arrow"
+	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google/externalaccount"
 	"google.golang.org/api/impersonate"
@@ -1370,6 +1371,26 @@ func (c *connectionImpl) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
+// newAccessTokenTransport builds the HTTP transport used to fetch access
+// tokens from a custom token endpoint (the refresh-token / token-server auth
+// path).
+//
+// A bare &http.Transport{} leaves Proxy nil, which makes it ignore the standard
+// proxy environment variables entirely. We wire up proxy handling from the
+// environment so that HTTP(S)_PROXY is honored *and* the NO_PROXY/no_proxy
+// bypass list is respected. httpproxy.FromEnvironment is read per call (rather
+// than the process-cached http.ProxyFromEnvironment) so the transport reflects
+// the current environment. See dbt-labs/dbt-core#14470.
+func newAccessTokenTransport(serverName string) *http.Transport {
+	proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+	return &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return proxyFunc(req.URL)
+		},
+		TLSClientConfig: &tls.Config{ServerName: serverName},
+	}
+}
+
 func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	params := url.Values{}
 	params.Add("grant_type", "refresh_token")
@@ -1386,11 +1407,8 @@ func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{ServerName: c.accessTokenServerName},
-	}
 	client := &http.Client{
-		Transport: tr,
+		Transport: newAccessTokenTransport(c.accessTokenServerName),
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -424,3 +424,47 @@ func TestBuildField(t *testing.T) {
 		})
 	}
 }
+
+// TestAccessTokenTransportHonorsNoProxy verifies that the transport used to
+// fetch access tokens honors the standard proxy environment variables,
+// including the NO_PROXY bypass list. A bare &http.Transport{} leaves Proxy
+// nil and would route (or fail to route) regardless of NO_PROXY. Regression
+// for dbt-labs/dbt-core#14470.
+func TestAccessTokenTransportHonorsNoProxy(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://proxy.internal:3128")
+	t.Setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+	t.Setenv("NO_PROXY", "token-server.example")
+
+	tr := newAccessTokenTransport("token-server.example")
+	if tr.Proxy == nil {
+		t.Fatal("access-token transport must set Proxy so proxy env vars are honored")
+	}
+
+	// A host on the NO_PROXY list must bypass the proxy (nil proxy URL).
+	bypassReq, err := http.NewRequest(http.MethodPost, "https://token-server.example/token", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	if u, err := tr.Proxy(bypassReq); err != nil {
+		t.Fatalf("unexpected error resolving proxy for NO_PROXY host: %v", err)
+	} else if u != nil {
+		t.Fatalf("NO_PROXY host should bypass proxy, got %q", u)
+	}
+
+	// A host not on the list must route through the configured proxy.
+	proxiedReq, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	u, err := tr.Proxy(proxiedReq)
+	if err != nil {
+		t.Fatalf("unexpected error resolving proxy: %v", err)
+	}
+	if u == nil || u.Host != "proxy.internal:3128" {
+		t.Fatalf("non-excluded host should use proxy proxy.internal:3128, got %v", u)
+	}
+
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.ServerName != "token-server.example" {
+		t.Fatalf("expected TLS ServerName to be preserved, got %+v", tr.TLSClientConfig)
+	}
+}

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -164,7 +164,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/net v0.46.0 // indirect
+	golang.org/x/net v0.46.0
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8 // indirect
 	golang.org/x/term v0.36.0 // indirect


### PR DESCRIPTION
## What

The HTTP transport used by `getAccessToken` (the refresh-token / custom-token-server auth path) in the BigQuery driver was built as a bare `&http.Transport{TLSClientConfig: ...}` with **no `Proxy` field**:

```go
tr := &http.Transport{
    TLSClientConfig: &tls.Config{ServerName: c.accessTokenServerName},
}
```

A nil `Proxy` means the transport ignores the standard proxy environment variables entirely. In a proxied environment the token fetch bypasses the proxy, and there is no way to express a `NO_PROXY`/`no_proxy` bypass for it.

## Fix

Extract a `newAccessTokenTransport` helper that wires `Proxy` through `httpproxy.FromEnvironment().ProxyFunc()`, so `HTTP(S)_PROXY` is honored **and** the `NO_PROXY` bypass list is respected — matching dbt-core's env-based proxy behavior. It's read per call (rather than the process-cached `http.ProxyFromEnvironment`) so the transport reflects the current environment, and the TLS `ServerName` override is preserved.

## Test

Added `TestAccessTokenTransportHonorsNoProxy` (no credentials/network required): with `HTTPS_PROXY` set and `NO_PROXY=token-server.example`, it asserts the transport (a) sets `Proxy`, (b) returns a nil proxy URL for the `NO_PROXY` host, (c) routes a non-excluded host through the proxy, and (d) preserves the TLS `ServerName`. `go build`, `go vet`, and `gofmt` are clean; `go mod tidy` promoted `golang.org/x/net` from indirect to direct (one line).

## Scope / relation to dbt-core#14470

This fixes proxy handling for the **access-token** HTTP path specifically. It is *related to* [dbt-labs/dbt-core#14470](https://github.com/dbt-labs/dbt-core/issues/14470) but does **not** fully close it: the main `*.googleapis.com` traffic goes through the google-cloud-go transport (REST + gRPC Storage Read), whose `NO_PROXY` handling is a separate, upstream concern. Filing this as a self-contained, verifiable improvement in the driver's own transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)