### PR TITLE
fix(go/bigquery): route bare api_endpoint through the /bigquery/v2 path (dbt-core#14615)

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -854,28 +854,15 @@ const bigQueryRESTPath = "/bigquery/v2/"
 // This matches dbt-core (v1), where the Python client library appends the REST
 // path to the api_endpoint passed via ClientOptions:
 // https://github.com/dbt-labs/dbt-adapters/blob/e008d8f6f7a7d76a6a63084512f4862f9bd41090/dbt-bigquery/src/dbt/adapters/bigquery/clients.py#L66-L76
-// An endpoint that already specifies any other non-root path is left untouched,
-// so emulators or callers that intentionally point at a custom path keep
-// working. See dbt-labs/dbt-core#14615.
+// See dbt-labs/dbt-core#14615.
 func normalizeBigQueryAPIEndpoint(endpoint string) string {
-	u, err := url.Parse(endpoint)
-	if err != nil || u.Host == "" {
-		// Not a parseable absolute URL (e.g. a bare "host:port" gRPC-style
-		// endpoint); leave it as-is.
-		return endpoint
+	trimmed := strings.TrimRight(endpoint, "/")
+	// Idempotent: an endpoint that already carries the REST path (e.g. a copy
+	// of the default) must not have it appended twice.
+	if strings.HasSuffix(trimmed, strings.TrimSuffix(bigQueryRESTPath, "/")) {
+		return trimmed + "/"
 	}
-	switch u.Path {
-	case "", "/":
-		u.Path = bigQueryRESTPath
-		return u.String()
-	case strings.TrimSuffix(bigQueryRESTPath, "/"):
-		// The REST client resolves relative paths against BasePath, so
-		// "/bigquery/v2" without the trailing slash would resolve
-		// "projects/..." to "/bigquery/projects/...".
-		u.Path = bigQueryRESTPath
-		return u.String()
-	}
-	return endpoint
+	return trimmed + bigQueryRESTPath
 }
 
 func (c *connectionImpl) newClient(ctx context.Context) error {

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -851,10 +851,12 @@ const bigQueryRESTPath = "/bigquery/v2/"
 // "https://proxy.example.com" (e.g. an Alvin proxy) would otherwise route
 // requests to "https://proxy.example.com/projects/..." instead of
 // "https://proxy.example.com/bigquery/v2/projects/...", which the proxy rejects.
-// dbt-core (Python) appends this path itself; mirror that behavior. An endpoint
-// that already specifies a non-root path is left untouched, so emulators or
-// callers that intentionally point at a custom path keep working.
-// See dbt-core#14615.
+// This matches dbt-core (v1), where the Python client library appends the REST
+// path to the api_endpoint passed via ClientOptions:
+// https://github.com/dbt-labs/dbt-adapters/blob/e008d8f6f7a7d76a6a63084512f4862f9bd41090/dbt-bigquery/src/dbt/adapters/bigquery/clients.py#L66-L76
+// An endpoint that already specifies any other non-root path is left untouched,
+// so emulators or callers that intentionally point at a custom path keep
+// working. See dbt-labs/dbt-core#14615.
 func normalizeBigQueryAPIEndpoint(endpoint string) string {
 	u, err := url.Parse(endpoint)
 	if err != nil || u.Host == "" {
@@ -862,7 +864,14 @@ func normalizeBigQueryAPIEndpoint(endpoint string) string {
 		// endpoint); leave it as-is.
 		return endpoint
 	}
-	if u.Path == "" || u.Path == "/" {
+	switch u.Path {
+	case "", "/":
+		u.Path = bigQueryRESTPath
+		return u.String()
+	case strings.TrimSuffix(bigQueryRESTPath, "/"):
+		// The REST client resolves relative paths against BasePath, so
+		// "/bigquery/v2" without the trailing slash would resolve
+		// "projects/..." to "/bigquery/projects/...".
 		u.Path = bigQueryRESTPath
 		return u.String()
 	}

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -838,6 +838,37 @@ func (c *connectionImpl) authOptions(ctx context.Context) ([]option.ClientOption
 	return authOptions, nil
 }
 
+// bigQueryRESTPath is the API path segment the google-cloud-go BigQuery REST
+// client (google.golang.org/api/bigquery/v2) appends to its default endpoint
+// (https://bigquery.googleapis.com/bigquery/v2/).
+const bigQueryRESTPath = "/bigquery/v2/"
+
+// normalizeBigQueryAPIEndpoint ensures a user-supplied api_endpoint carries the
+// "/bigquery/v2/" REST path.
+//
+// option.WithEndpoint replaces the client's entire BasePath, not just the host.
+// The default BasePath already includes "/bigquery/v2/", so a bare host such as
+// "https://proxy.example.com" (e.g. an Alvin proxy) would otherwise route
+// requests to "https://proxy.example.com/projects/..." instead of
+// "https://proxy.example.com/bigquery/v2/projects/...", which the proxy rejects.
+// dbt-core (Python) appends this path itself; mirror that behavior. An endpoint
+// that already specifies a non-root path is left untouched, so emulators or
+// callers that intentionally point at a custom path keep working.
+// See dbt-core#14615.
+func normalizeBigQueryAPIEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		// Not a parseable absolute URL (e.g. a bare "host:port" gRPC-style
+		// endpoint); leave it as-is.
+		return endpoint
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = bigQueryRESTPath
+		return u.String()
+	}
+	return endpoint
+}
+
 func (c *connectionImpl) newClient(ctx context.Context) error {
 	if c.catalog == "" {
 		return adbc.Error{
@@ -852,7 +883,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	}
 	if c.apiEndpoint != "" {
 		// Safe to append: the default endpoint is already assumed by the client, so this only adds a user-specified override.
-		authOptions = append(authOptions, option.WithEndpoint(c.apiEndpoint))
+		authOptions = append(authOptions, option.WithEndpoint(normalizeBigQueryAPIEndpoint(c.apiEndpoint)))
 	}
 
 	storageReadClient, err := bigquery.NewClient(ctx, c.catalog, authOptions...)

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -58,6 +58,7 @@ func TestNormalizeBigQueryAPIEndpoint(t *testing.T) {
 		{"root path gets /bigquery/v2/ appended", "https://proxy.example.com/", "https://proxy.example.com/bigquery/v2/"},
 		{"host with port gets path appended", "http://localhost:9050", "http://localhost:9050/bigquery/v2/"},
 		{"already-correct endpoint is unchanged", "https://bigquery.googleapis.com/bigquery/v2/", "https://bigquery.googleapis.com/bigquery/v2/"},
+		{"REST path missing trailing slash gets it added", "https://proxy.example.com/bigquery/v2", "https://proxy.example.com/bigquery/v2/"},
 		{"explicit custom path is left untouched", "http://localhost:9050/custom/path", "http://localhost:9050/custom/path"},
 		{"non-URL endpoint is left untouched", "localhost:9060", "localhost:9060"},
 	}
@@ -73,7 +74,7 @@ func TestNormalizeBigQueryAPIEndpoint(t *testing.T) {
 // TestAPIEndpointRoutesToBigQueryV2Path confirms end-to-end (through the real
 // google-cloud-go BigQuery client) that a bare api_endpoint host now routes
 // requests to the "/bigquery/v2/..." path a real BigQuery proxy expects, rather
-// than dropping the path. Regression for dbt-core#14615.
+// than dropping the path. Regression for dbt-labs/dbt-core#14615.
 func TestAPIEndpointRoutesToBigQueryV2Path(t *testing.T) {
 	paths := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -59,8 +59,7 @@ func TestNormalizeBigQueryAPIEndpoint(t *testing.T) {
 		{"host with port gets path appended", "http://localhost:9050", "http://localhost:9050/bigquery/v2/"},
 		{"already-correct endpoint is unchanged", "https://bigquery.googleapis.com/bigquery/v2/", "https://bigquery.googleapis.com/bigquery/v2/"},
 		{"REST path missing trailing slash gets it added", "https://proxy.example.com/bigquery/v2", "https://proxy.example.com/bigquery/v2/"},
-		{"explicit custom path is left untouched", "http://localhost:9050/custom/path", "http://localhost:9050/custom/path"},
-		{"non-URL endpoint is left untouched", "localhost:9060", "localhost:9060"},
+		{"schemeless host:port gets path appended", "localhost:9060", "localhost:9060/bigquery/v2/"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -28,6 +28,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"golang.org/x/oauth2/google/externalaccount"
+	"google.golang.org/api/option"
 )
 
 func TestDatabaseAPIEndpointOption(t *testing.T) {
@@ -44,6 +45,67 @@ func TestDatabaseAPIEndpointOption(t *testing.T) {
 	}
 	if got != "https://bigquery.googleapis.com/bigquery/v2/" {
 		t.Fatalf("expected endpoint to round-trip, got %q", got)
+	}
+}
+
+func TestNormalizeBigQueryAPIEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare host gets /bigquery/v2/ appended", "https://dbtlabs-com.opti.alvin.ai", "https://dbtlabs-com.opti.alvin.ai/bigquery/v2/"},
+		{"root path gets /bigquery/v2/ appended", "https://proxy.example.com/", "https://proxy.example.com/bigquery/v2/"},
+		{"host with port gets path appended", "http://localhost:9050", "http://localhost:9050/bigquery/v2/"},
+		{"already-correct endpoint is unchanged", "https://bigquery.googleapis.com/bigquery/v2/", "https://bigquery.googleapis.com/bigquery/v2/"},
+		{"explicit custom path is left untouched", "http://localhost:9050/custom/path", "http://localhost:9050/custom/path"},
+		{"non-URL endpoint is left untouched", "localhost:9060", "localhost:9060"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeBigQueryAPIEndpoint(tc.in); got != tc.want {
+				t.Fatalf("normalizeBigQueryAPIEndpoint(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAPIEndpointRoutesToBigQueryV2Path confirms end-to-end (through the real
+// google-cloud-go BigQuery client) that a bare api_endpoint host now routes
+// requests to the "/bigquery/v2/..." path a real BigQuery proxy expects, rather
+// than dropping the path. Regression for dbt-core#14615.
+func TestAPIEndpointRoutesToBigQueryV2Path(t *testing.T) {
+	paths := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case paths <- r.URL.Path:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jobComplete":true,"jobReference":{"jobId":"x"},"schema":{"fields":[]},"rows":[]}`))
+	}))
+	defer srv.Close()
+
+	// srv.URL is a bare host (http://127.0.0.1:PORT), like a user-supplied
+	// api_endpoint; after normalization the request must carry /bigquery/v2/.
+	client, err := bigquery.NewClient(context.Background(), "test-proj",
+		option.WithEndpoint(normalizeBigQueryAPIEndpoint(srv.URL)),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+	_, _ = client.Query("SELECT 1").Read(context.Background())
+
+	var got string
+	select {
+	case got = <-paths:
+	default:
+		t.Fatal("no request reached the test server")
+	}
+	if !strings.HasPrefix(got, "/bigquery/v2/") {
+		t.Fatalf("expected request path to start with /bigquery/v2/, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Resolves: dbt-labs/dbt-core#14615

## Problem

[dbt-core#14615](https://github.com/dbt-labs/dbt-core/issues/14615): a BigQuery `api_endpoint` pointing at a proxy (e.g. Alvin, `https://dbtlabs-com.opti.alvin.ai`) works with dbt Core but not Fusion. The proxy expects requests under `/bigquery/v2/...`; Fusion sends them to `/projects/...`.

## Repro

1. In `profiles.yml`, set `api_endpoint: https://<bigquery-proxy-host>` (bare host, no path) on a BigQuery profile.
2. Run any command that issues a query (`dbt debug`, `dbt run`).
3. Before: requests go to `https://<host>/projects/<project>/queries` and the proxy 404s; expected (and dbt Core behavior): `https://<host>/bigquery/v2/projects/<project>/queries`.

## Root cause

`newClient` passes the user's `api_endpoint` straight to `option.WithEndpoint`. In google-cloud-go, `WithEndpoint` replaces the BigQuery client's **entire** `BasePath`, and the default BasePath is `https://bigquery.googleapis.com/bigquery/v2/` (path included). So a bare-host endpoint yields a BasePath with no `/bigquery/v2/`, and requests go to `https://host/projects/...`.

dbt Core (v1) works because the Python client library appends the REST path to the `api_endpoint` passed via `ClientOptions` in [`clients.py#_create_bigquery_client`](https://github.com/dbt-labs/dbt-adapters/blob/e008d8f6f7a7d76a6a63084512f4862f9bd41090/dbt-bigquery/src/dbt/adapters/bigquery/clients.py#L66-L76).

## Fix

`normalizeBigQueryAPIEndpoint` appends `/bigquery/v2/` to a bare-host `api_endpoint` before handing it to `WithEndpoint`, and adds the trailing slash to an endpoint ending in exactly `/bigquery/v2` (without it, the REST client resolves relative paths against the parent segment, yielding `/bigquery/projects/...`). Endpoints that already carry any other non-root path (custom emulator paths, or an already-correct endpoint) are left untouched, as are non-URL/gRPC-style `host:port` values.

Notes:
- The normalized endpoint is also passed to `EnableStorageReadClient`; the gRPC Storage Read client dials lazily and was already unusable through path-rewriting REST proxies, so this does not regress anything (see #140 for the Storage-API fallback in that scenario).
- Emulator note: goccy/bigquery-emulator serves both `/` and `/bigquery/v2/`-prefixed routes, so a scheme-ful bare-host emulator endpoint keeps working after normalization.

## Validation

- `TestNormalizeBigQueryAPIEndpoint` — table-driven coverage of bare host, root path, host:port, already-correct, missing-trailing-slash, explicit custom path, and non-URL inputs.
- `TestAPIEndpointRoutesToBigQueryV2Path` — end-to-end through the **real** google-cloud-go BigQuery client against an `httptest` server. Before the fix a bare host hit `/projects/test-proj/queries`; it now hits `/bigquery/v2/projects/test-proj/queries`.
