### PR TITLE
fix(go/bigquery): fall back to REST result fetching when api_endpoint is set (dbt-core#14617)

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -575,6 +575,14 @@ func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
 		parameterMode:          OptionValueQueryParameterModePositional,
 		resultRecordBufferSize: c.resultRecordBufferSize,
 		prefetchConcurrency:    c.prefetchConcurrency,
+		// When a custom api_endpoint is configured (e.g. a proxy or the
+		// BigQuery emulator), the BigQuery Storage Read API (gRPC) is generally
+		// not reachable at that host, so results must be fetched over the REST
+		// jobs API instead. Default to the Storage-API-disabled client in that
+		// case to avoid "Storage API is not available for query" failures. The
+		// caller can still override this per statement via
+		// OptionBoolUseStorageApiDisabledClient. See dbt-core#14617.
+		useStorageApiDisabledClient: c.apiEndpoint != "",
 		queryConfig: bigquery.QueryConfig{
 			DefaultProjectID: c.catalog,
 			DefaultDatasetID: c.dbSchema,

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -90,6 +90,11 @@ type connectionImpl struct {
 	resultRecordBufferSize int
 	prefetchConcurrency    int
 
+	// Connection-level override for OptionBoolUseStorageApiDisabledClient;
+	// when nil, new statements default to REST result fetching iff a custom
+	// apiEndpoint is set.
+	useStorageApiDisabledClient *bool
+
 	client                   *bigquery.Client
 	clientStorageApiDisabled *bigquery.Client // Client without Storage API for queries that use pseudo-columns like _PARTITIONDATE and _PARTITIONTIME
 }
@@ -569,17 +574,22 @@ func (c *connectionImpl) GetTableSchema(ctx context.Context, catalog *string, db
 
 // NewStatement initializes a new statement object tied to this connection
 func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
+	// The Storage Read API (gRPC) is generally unreachable at a custom
+	// api_endpoint (proxy/emulator), so default to REST result fetching
+	// unless the connection option says otherwise; also overridable per
+	// statement via OptionBoolUseStorageApiDisabledClient.
+	// See dbt-labs/dbt-core#14617.
+	useStorageApiDisabledClient := c.apiEndpoint != ""
+	if c.useStorageApiDisabledClient != nil {
+		useStorageApiDisabledClient = *c.useStorageApiDisabledClient
+	}
 	return &statement{
-		alloc:                  c.Alloc,
-		cnxn:                   c,
-		parameterMode:          OptionValueQueryParameterModePositional,
-		resultRecordBufferSize: c.resultRecordBufferSize,
-		prefetchConcurrency:    c.prefetchConcurrency,
-		// The Storage Read API (gRPC) is generally unreachable at a custom
-		// api_endpoint (proxy/emulator), so default to REST result fetching;
-		// overridable per statement via OptionBoolUseStorageApiDisabledClient.
-		// See dbt-labs/dbt-core#14617.
-		useStorageApiDisabledClient: c.apiEndpoint != "",
+		alloc:                       c.Alloc,
+		cnxn:                        c,
+		parameterMode:               OptionValueQueryParameterModePositional,
+		resultRecordBufferSize:      c.resultRecordBufferSize,
+		prefetchConcurrency:         c.prefetchConcurrency,
+		useStorageApiDisabledClient: useStorageApiDisabledClient,
 		queryConfig: bigquery.QueryConfig{
 			DefaultProjectID: c.catalog,
 			DefaultDatasetID: c.dbSchema,
@@ -626,6 +636,11 @@ func (c *connectionImpl) GetOption(key string) (string, error) {
 			return "", nil
 		}
 		return c.impersonateLifetime.String(), nil
+	case OptionBoolUseStorageApiDisabledClient:
+		if c.useStorageApiDisabledClient != nil {
+			return strconv.FormatBool(*c.useStorageApiDisabledClient), nil
+		}
+		return strconv.FormatBool(c.apiEndpoint != ""), nil
 	default:
 		return c.ConnectionImplBase.GetOption(key)
 	}
@@ -680,6 +695,15 @@ func (c *connectionImpl) SetOption(key string, value string) error {
 			}
 		}
 		c.impersonateLifetime = dur
+	case OptionBoolUseStorageApiDisabledClient:
+		val, err := strconv.ParseBool(value)
+		if err != nil {
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("Invalid boolean string for %s: %s", OptionBoolUseStorageApiDisabledClient, err.Error()),
+			}
+		}
+		c.useStorageApiDisabledClient = &val
 	default:
 		return c.ConnectionImplBase.SetOption(key, value)
 	}

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -575,13 +575,10 @@ func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
 		parameterMode:          OptionValueQueryParameterModePositional,
 		resultRecordBufferSize: c.resultRecordBufferSize,
 		prefetchConcurrency:    c.prefetchConcurrency,
-		// When a custom api_endpoint is configured (e.g. a proxy or the
-		// BigQuery emulator), the BigQuery Storage Read API (gRPC) is generally
-		// not reachable at that host, so results must be fetched over the REST
-		// jobs API instead. Default to the Storage-API-disabled client in that
-		// case to avoid "Storage API is not available for query" failures. The
-		// caller can still override this per statement via
-		// OptionBoolUseStorageApiDisabledClient. See dbt-core#14617.
+		// The Storage Read API (gRPC) is generally unreachable at a custom
+		// api_endpoint (proxy/emulator), so default to REST result fetching;
+		// overridable per statement via OptionBoolUseStorageApiDisabledClient.
+		// See dbt-labs/dbt-core#14617.
 		useStorageApiDisabledClient: c.apiEndpoint != "",
 		queryConfig: bigquery.QueryConfig{
 			DefaultProjectID: c.catalog,

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -47,6 +47,33 @@ func TestDatabaseAPIEndpointOption(t *testing.T) {
 	}
 }
 
+// TestNewStatementStorageApiDisabledDefault verifies that statements created on
+// a connection with a custom api_endpoint default to the Storage-API-disabled
+// (REST) result path, so a proxy/emulator that lacks the gRPC Storage Read API
+// does not fail with "Storage API is not available". Regression for
+// dbt-core#14617.
+func TestNewStatementStorageApiDisabledDefault(t *testing.T) {
+	// No custom endpoint: Storage Read API path stays enabled.
+	plain := &connectionImpl{}
+	stmt, err := plain.NewStatement()
+	if err != nil {
+		t.Fatalf("NewStatement: %v", err)
+	}
+	if st := stmt.(*statement); st.useStorageApiDisabledClient {
+		t.Fatalf("expected Storage API enabled by default without api_endpoint")
+	}
+
+	// Custom endpoint: default to the disabled (REST) client.
+	custom := &connectionImpl{apiEndpoint: "http://localhost:9050"}
+	stmt2, err := custom.NewStatement()
+	if err != nil {
+		t.Fatalf("NewStatement: %v", err)
+	}
+	if st := stmt2.(*statement); !st.useStorageApiDisabledClient {
+		t.Fatalf("expected Storage-API-disabled client default when api_endpoint is set")
+	}
+}
+
 func TestCustomAccessTokenEndpointAndServerName(t *testing.T) {
 	accessTokenEndpoint := "https://example.com/oauth2/token"
 	accessTokenServerName := "example.com"

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -72,6 +72,34 @@ func TestNewStatementStorageApiDisabledDefault(t *testing.T) {
 	if st := stmt2.(*statement); !st.useStorageApiDisabledClient {
 		t.Fatalf("expected Storage-API-disabled client default when api_endpoint is set")
 	}
+
+	// The connection-level option overrides the endpoint-based default in
+	// both directions (e.g. a PSC endpoint where Storage Read is reachable).
+	if err := custom.SetOption(OptionBoolUseStorageApiDisabledClient, "false"); err != nil {
+		t.Fatalf("SetOption: %v", err)
+	}
+	stmt3, err := custom.NewStatement()
+	if err != nil {
+		t.Fatalf("NewStatement: %v", err)
+	}
+	if st := stmt3.(*statement); st.useStorageApiDisabledClient {
+		t.Fatalf("expected connection option false to keep Storage API enabled despite api_endpoint")
+	}
+
+	if err := plain.SetOption(OptionBoolUseStorageApiDisabledClient, "true"); err != nil {
+		t.Fatalf("SetOption: %v", err)
+	}
+	stmt4, err := plain.NewStatement()
+	if err != nil {
+		t.Fatalf("NewStatement: %v", err)
+	}
+	if st := stmt4.(*statement); !st.useStorageApiDisabledClient {
+		t.Fatalf("expected connection option true to disable Storage API without api_endpoint")
+	}
+
+	if got, err := custom.GetOption(OptionBoolUseStorageApiDisabledClient); err != nil || got != "false" {
+		t.Fatalf("GetOption = %q, %v; want \"false\"", got, err)
+	}
 }
 
 func TestCustomAccessTokenEndpointAndServerName(t *testing.T) {

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -92,7 +92,9 @@ const (
 
 	// OptionBoolUseStorageApiDisabledClient instructs the driver to use the legacy RowIterator API
 	// instead of the Storage Read API. This is required for queries that reference
-	// pseudo-columns like _PARTITIONDATE and _PARTITIONTIME.
+	// pseudo-columns like _PARTITIONDATE and _PARTITIONTIME. Settable on a
+	// statement, or on a connection to set the default for its new statements
+	// (overriding the api_endpoint-based default).
 	OptionBoolUseStorageApiDisabledClient = "adbc.bigquery.sql.query.use_storage_api_disabled_client"
 
 	defaultQueryResultBufferSize    = 200


### PR DESCRIPTION
Resolves: dbt-labs/dbt-core#14617

## Problem

[dbt-core#14617](https://github.com/dbt-labs/dbt-core/issues/14617): Fusion fetches results through the BigQuery **Storage Read API (gRPC)**. When `api_endpoint` points at a proxy or the [bigquery-emulator](https://github.com/goccy/bigquery-emulator), REST traffic is routed there but the gRPC Storage Read service is not reachable at that host, so any command fails with:

```
[BigQuery] Storage API is not available for query: ...
```

The maintainer of the reporting thread explicitly asked for an **opt-out of routing the Storage Read API** when `api_endpoint` is set.

## Repro

1. In `profiles.yml`, set `api_endpoint` to a REST-only host (a BigQuery proxy, or a local bigquery-emulator).
2. Run any query (`dbt debug` / `dbt run`).
3. Before: fails with `Storage API is not available for query`; after: results are fetched over the REST jobs API and the command succeeds.

## Fix

The driver already has a Storage-API-disabled client that fetches results via the REST jobs API (`OptionBoolUseStorageApiDisabledClient`). Default new statements to that path when the connection has a custom `api_endpoint`, so proxies/emulators work without extra configuration.

Per review: callers targeting an endpoint that *does* expose Storage Read (e.g. Private Service Connect / regional endpoints) can re-enable it — `OptionBoolUseStorageApiDisabledClient` is now settable on the **connection** as well (overriding the endpoint-based default for its statements in either direction), in addition to the existing per-statement option.

**Follow-up (separate PR, per review):** a `storage_api_endpoint`-style option plumbed to `EnableStorageReadClient`, so the REST endpoint and the Storage Read endpoint (e.g. bigquery-emulator's gRPC port) can be configured independently.

## dbt-core (v1) parallel

This failure mode is Fusion-only: dbt-bigquery (Python) never uses the Storage Read API for query results — it fetches over REST via the client built in [`clients.py#_create_bigquery_client`](https://github.com/dbt-labs/dbt-adapters/blob/e008d8f6f7a7d76a6a63084512f4862f9bd41090/dbt-bigquery/src/dbt/adapters/bigquery/clients.py#L66-L76), which is why the same profile works on dbt Core.

## Tests

`TestNewStatementStorageApiDisabledDefault` — a statement from a plain connection keeps the Storage Read API enabled; a statement from a connection with `api_endpoint` set defaults to the disabled (REST) client (fails without the fix); and the connection-level option overrides the default in both directions.
