### PR TITLE
fix(go/bigquery): honor HTTPS_PROXY/NO_PROXY on the token-exchange transport (dbt-core#14470)

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -1387,6 +1387,12 @@ func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	req.Header.Set("Accept", "application/json")
 
 	tr := &http.Transport{
+		// Honor HTTPS_PROXY / NO_PROXY like the rest of the driver's HTTP
+		// traffic. A custom http.Transport defaults Proxy to nil (no proxy),
+		// unlike http.DefaultTransport; without this, the token-exchange request
+		// bypasses a configured proxy entirely and, conversely, cannot be
+		// excluded via NO_PROXY. See dbt-labs/dbt-core#14470.
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{ServerName: c.accessTokenServerName},
 	}
 	client := &http.Client{

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -1370,6 +1369,18 @@ func (c *connectionImpl) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
+// newTokenExchangeTransport returns the transport for OAuth token-exchange
+// requests. A custom http.Transport defaults Proxy to nil, unlike
+// http.DefaultTransport, so it must be set explicitly for the token exchange
+// to honor HTTPS_PROXY/NO_PROXY like the rest of the driver's HTTP traffic.
+// See dbt-labs/dbt-core#14470.
+func (c *connectionImpl) newTokenExchangeTransport() *http.Transport {
+	return &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{ServerName: c.accessTokenServerName},
+	}
+}
+
 func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	params := url.Values{}
 	params.Add("grant_type", "refresh_token")
@@ -1386,21 +1397,12 @@ func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	tr := &http.Transport{
-		// Honor HTTPS_PROXY / NO_PROXY like the rest of the driver's HTTP
-		// traffic. A custom http.Transport defaults Proxy to nil (no proxy),
-		// unlike http.DefaultTransport; without this, the token-exchange request
-		// bypasses a configured proxy entirely and, conversely, cannot be
-		// excluded via NO_PROXY. See dbt-labs/dbt-core#14470.
-		Proxy:           http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{ServerName: c.accessTokenServerName},
-	}
 	client := &http.Client{
-		Transport: tr,
+		Transport: c.newTokenExchangeTransport(),
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func(Body io.ReadCloser) {
 		bodyErr := Body.Close()
@@ -1411,7 +1413,7 @@ func (c *connectionImpl) getAccessToken() (*bigQueryTokenResponse, error) {
 
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	var tokenResponse bigQueryTokenResponse

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -119,6 +120,41 @@ func TestCustomAccessTokenEndpoint(t *testing.T) {
 	}
 	if conn.accessTokenServerName != "" {
 		t.Errorf("Expected access token server name to be blank, but got %s", conn.accessTokenServerName)
+	}
+}
+
+// getAccessToken previously built its transport without a Proxy function,
+// silently bypassing HTTPS_PROXY/NO_PROXY (dbt-labs/dbt-core#14470). The
+// wiring is pinned structurally because http.ProxyFromEnvironment caches the
+// proxy environment on first use, which makes an in-process env-based
+// end-to-end check order-dependent on other tests.
+func TestTokenExchangeTransportUsesEnvProxy(t *testing.T) {
+	conn := &connectionImpl{accessTokenServerName: "example.com"}
+	tr := conn.newTokenExchangeTransport()
+	if tr.Proxy == nil {
+		t.Fatal("token-exchange transport must set Proxy so HTTPS_PROXY/NO_PROXY are honored")
+	}
+	got := reflect.ValueOf(tr.Proxy).Pointer()
+	want := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+	if got != want {
+		t.Errorf("token-exchange transport Proxy must be http.ProxyFromEnvironment")
+	}
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.ServerName != "example.com" {
+		t.Errorf("token-exchange transport must preserve TLS ServerName, got %+v", tr.TLSClientConfig)
+	}
+}
+
+// A failing token-exchange request (e.g. an unreachable or misconfigured
+// proxy) must surface as an error to the caller, not kill the process.
+func TestGetAccessTokenReturnsErrorOnRequestFailure(t *testing.T) {
+	conn := &connectionImpl{
+		clientID:            "test-client-id",
+		clientSecret:        "test-client-secret",
+		refreshToken:        "test-refresh-token",
+		accessTokenEndpoint: "http://127.0.0.1:1",
+	}
+	if _, err := conn.getAccessToken(); err == nil {
+		t.Fatal("expected an error for an unreachable token endpoint")
 	}
 }
 


### PR DESCRIPTION
Resolves: dbt-labs/dbt-core#14470

## Context

[dbt-core#14470](https://github.com/dbt-labs/dbt-core/issues/14470): Fusion honored `HTTPS_PROXY` but appeared to ignore `NO_PROXY` for `*.googleapis.com`.

## Investigation

On the **currently pinned** dependencies, the main BigQuery data paths already honor `NO_PROXY` via Go's standard `http.ProxyFromEnvironment`:
- REST: `google.golang.org/api/transport/http` builds its transport with `Proxy: http.ProxyFromEnvironment` (`dial.go`).
- gRPC (Storage Read): `google.golang.org/grpc` v1.76's `delegatingresolver` resolves the proxy via `http.ProxyFromEnvironment`, which consults `NO_PROXY`.

The original report was on `2.0.0-preview.164`, which predates grpc-go's `NO_PROXY` support — so the gRPC path there did not honor `NO_PROXY`. That has since been fixed upstream via the dependency bump. (Separately, note Go's `httpproxy` does **not** support `*` wildcards in `NO_PROXY`; `*.googleapis.com` never matches — use `.googleapis.com`.)

## Remaining gap fixed here

The one place in the driver that still ignored proxy env is the user-auth **token-exchange** request, which constructs its own `*http.Transport` with only a `TLSClientConfig`. A custom `http.Transport` defaults `Proxy` to `nil` (no proxy) — unlike `http.DefaultTransport`. So this request neither used a required `HTTPS_PROXY` nor could be excluded via `NO_PROXY`.

Set `Proxy: http.ProxyFromEnvironment` (extracted to `newTokenExchangeTransport`) so the token exchange respects the same proxy semantics as the rest of the driver.

Additionally, `getAccessToken` called `log.Fatal` on request/read failures — with proxies honored, a misconfigured or unreachable `HTTPS_PROXY` would have terminated the whole host process. Those paths now return errors to the caller.

## Repro

1. Point `HTTPS_PROXY` at an intercepting proxy (e.g. mitmproxy) and run a user-auth (`client_id`/`client_secret`/`refresh_token`) BigQuery connection.
2. Before: every request appears at the proxy **except** the token-exchange `POST` to `oauth2.googleapis.com/token`, which goes direct; setting `NO_PROXY=.googleapis.com` likewise has no effect on it.
3. After: the token exchange routes through the proxy and honors `NO_PROXY`.

## Python (dbt-core v1) parallel

There is no equivalent fix needed in dbt-bigquery: it delegates token exchange to `google-auth`, whose `requests`-based transport honors proxy environment variables natively. The credentialed client is built in [`clients.py#_create_bigquery_client`](https://github.com/dbt-labs/dbt-adapters/blob/e008d8f6f7a7d76a6a63084512f4862f9bd41090/dbt-bigquery/src/dbt/adapters/bigquery/clients.py#L66-L76).

## Tests

- `TestTokenExchangeTransportUsesEnvProxy` (new) — pins the token-exchange transport to `http.ProxyFromEnvironment` and preserves the TLS `ServerName`; fails without the fix.
- `TestGetAccessTokenReturnsErrorOnRequestFailure` (new) — an unreachable token endpoint surfaces as an error instead of `log.Fatal` killing the process.
- Existing token-endpoint tests (`TestCustomAccessTokenEndpoint`, `TestDefaultAccessTokenEndpoint`, `TestTemporaryAccessToken*`) still pass.
