### PR TITLE
chore(go/adbc): bump gosnowflake to v1.17.10

### DIFF
--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -70,7 +70,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 )
 
-replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.9
+replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.10
 
 replace github.com/databricks/databricks-sql-go => github.com/dbt-labs/databricks-sql-go v1.19.1
 

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dbt-labs/databricks-sql-go v1.19.1 h1:kQWYSmDv1piGsUTpctyILYMRgZXNsFedZo/1QmWzxcA=
 github.com/dbt-labs/databricks-sql-go v1.19.1/go.mod h1:TGAVzvXadeKI8me3nKBa/2phLNnyWR6OolYq6iYbN3E=
-github.com/dbt-labs/gosnowflake v1.17.9 h1:Hx41lYcu5JrxuK/Ii2KSwctVDFfrlmcfZuB9pJHyRyI=
-github.com/dbt-labs/gosnowflake v1.17.9/go.mod h1:WPSInfc1Uemdhr6PQbPp0C7LW7j4u6pIe/+g2QuOwkQ=
+github.com/dbt-labs/gosnowflake v1.17.10 h1:HLLXfiU0yMDhsDsKBPIZBWAVFL/LIJzkasx9tY0WXbM=
+github.com/dbt-labs/gosnowflake v1.17.10/go.mod h1:WPSInfc1Uemdhr6PQbPp0C7LW7j4u6pIe/+g2QuOwkQ=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## What

Bumps `github.com/dbt-labs/gosnowflake` to `v1.17.10`.

## Why

Picks up the Snowflake REST polling cancellation fix from https://github.com/dbt-labs/gosnowflake/pull/32, preventing a Go panic when client-side cancellation interrupts a long-running query.