### PR TITLE
feat(go/adbc/driver/bigquery): adding api endpoint configuration knobs for a REST API default

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -20,6 +20,7 @@ package bigquery
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,17 +31,18 @@ import (
 type databaseImpl struct {
 	driverbase.DatabaseImplBase
 
-	authType              string
-	accessToken           string
-	credentials           string
-	clientID              string
-	clientSecret          string
-	refreshToken          string
-	accessTokenEndpoint   string
-	accessTokenServerName string
-	apiEndpoint           string
-	location              string
-	quotaProject          string
+	authType                   string
+	accessToken                string
+	credentials                string
+	clientID                   string
+	clientSecret               string
+	refreshToken               string
+	accessTokenEndpoint        string
+	accessTokenServerName      string
+	apiEndpoint                string
+	endpointUsesReadStorageAPI *bool
+	location                   string
+	quotaProject               string
 
 	// External-account (Workload Identity Federation) options.
 	externalAccountAudience         string
@@ -76,6 +78,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		accessTokenEndpoint:             d.accessTokenEndpoint,
 		accessTokenServerName:           d.accessTokenServerName,
 		apiEndpoint:                     d.apiEndpoint,
+		endpointUsesReadStorageAPI:      d.endpointUsesReadStorageAPI,
 		externalAccountAudience:         d.externalAccountAudience,
 		externalAccountImpersonationURL: d.externalAccountImpersonationURL,
 		externalAccountRequestURL:       d.externalAccountRequestURL,
@@ -130,6 +133,11 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.externalAccountRequestData, nil
 	case OptionStringAPIEndpoint:
 		return d.apiEndpoint, nil
+	case OptionBoolEndpointUsesReadStorageAPI:
+		if d.endpointUsesReadStorageAPI != nil {
+			return strconv.FormatBool(*d.endpointUsesReadStorageAPI), nil
+		}
+		return "", nil
 	case OptionStringLocation:
 		return d.location, nil
 	case OptionStringProjectID:
@@ -215,6 +223,15 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.externalAccountRequestData = value
 	case OptionStringAPIEndpoint:
 		d.apiEndpoint = value
+	case OptionBoolEndpointUsesReadStorageAPI:
+		val, err := strconv.ParseBool(value)
+		if err != nil {
+			return adbc.Error{
+				Code: adbc.StatusInvalidArgument,
+				Msg:  fmt.Sprintf("invalid boolean value for %s: %s", OptionBoolEndpointUsesReadStorageAPI, err.Error()),
+			}
+		}
+		d.endpointUsesReadStorageAPI = &val
 	case OptionStringLocation:
 		d.location = value
 	case OptionStringImpersonateTargetPrincipal:

--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -20,7 +20,6 @@ package bigquery
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -31,18 +30,18 @@ import (
 type databaseImpl struct {
 	driverbase.DatabaseImplBase
 
-	authType                   string
-	accessToken                string
-	credentials                string
-	clientID                   string
-	clientSecret               string
-	refreshToken               string
-	accessTokenEndpoint        string
-	accessTokenServerName      string
-	apiEndpoint                string
-	endpointUsesReadStorageAPI *bool
-	location                   string
-	quotaProject               string
+	authType               string
+	accessToken            string
+	credentials            string
+	clientID               string
+	clientSecret           string
+	refreshToken           string
+	accessTokenEndpoint    string
+	accessTokenServerName  string
+	apiEndpoint            string
+	storageReadAPIEndpoint string
+	location               string
+	quotaProject           string
 
 	// External-account (Workload Identity Federation) options.
 	externalAccountAudience         string
@@ -63,6 +62,13 @@ type databaseImpl struct {
 }
 
 func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
+	if d.apiEndpoint != "" && d.storageReadAPIEndpoint != "" {
+		return nil, adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  fmt.Sprintf("only one of %s or %s may be set", OptionStringAPIEndpoint, OptionStringStorageReadAPIEndpoint),
+		}
+	}
+
 	conn := &connectionImpl{
 		ConnectionImplBase:              driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
 		authType:                        d.authType,
@@ -78,7 +84,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		accessTokenEndpoint:             d.accessTokenEndpoint,
 		accessTokenServerName:           d.accessTokenServerName,
 		apiEndpoint:                     d.apiEndpoint,
-		endpointUsesReadStorageAPI:      d.endpointUsesReadStorageAPI,
+		storageReadAPIEndpoint:          d.storageReadAPIEndpoint,
 		externalAccountAudience:         d.externalAccountAudience,
 		externalAccountImpersonationURL: d.externalAccountImpersonationURL,
 		externalAccountRequestURL:       d.externalAccountRequestURL,
@@ -133,11 +139,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.externalAccountRequestData, nil
 	case OptionStringAPIEndpoint:
 		return d.apiEndpoint, nil
-	case OptionBoolEndpointUsesReadStorageAPI:
-		if d.endpointUsesReadStorageAPI != nil {
-			return strconv.FormatBool(*d.endpointUsesReadStorageAPI), nil
-		}
-		return "", nil
+	case OptionStringStorageReadAPIEndpoint:
+		return d.storageReadAPIEndpoint, nil
 	case OptionStringLocation:
 		return d.location, nil
 	case OptionStringProjectID:
@@ -223,15 +226,8 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.externalAccountRequestData = value
 	case OptionStringAPIEndpoint:
 		d.apiEndpoint = value
-	case OptionBoolEndpointUsesReadStorageAPI:
-		val, err := strconv.ParseBool(value)
-		if err != nil {
-			return adbc.Error{
-				Code: adbc.StatusInvalidArgument,
-				Msg:  fmt.Sprintf("invalid boolean value for %s: %s", OptionBoolEndpointUsesReadStorageAPI, err.Error()),
-			}
-		}
-		d.endpointUsesReadStorageAPI = &val
+	case OptionStringStorageReadAPIEndpoint:
+		d.storageReadAPIEndpoint = value
 	case OptionStringLocation:
 		d.location = value
 	case OptionStringImpersonateTargetPrincipal:

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -65,6 +65,8 @@ type connectionImpl struct {
 	accessTokenServerName string
 	apiEndpoint           string
 
+	endpointUsesReadStorageAPI *bool
+
 	// External-account (Workload Identity Federation) options.
 	externalAccountAudience         string
 	externalAccountImpersonationURL string
@@ -569,12 +571,17 @@ func (c *connectionImpl) GetTableSchema(ctx context.Context, catalog *string, db
 
 // NewStatement initializes a new statement object tied to this connection
 func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
+	storageRead := c.apiEndpoint == ""
+	if c.endpointUsesReadStorageAPI != nil {
+		storageRead = *c.endpointUsesReadStorageAPI
+	}
 	return &statement{
-		alloc:                  c.Alloc,
-		cnxn:                   c,
-		parameterMode:          OptionValueQueryParameterModePositional,
-		resultRecordBufferSize: c.resultRecordBufferSize,
-		prefetchConcurrency:    c.prefetchConcurrency,
+		alloc:                       c.Alloc,
+		cnxn:                        c,
+		parameterMode:               OptionValueQueryParameterModePositional,
+		resultRecordBufferSize:      c.resultRecordBufferSize,
+		prefetchConcurrency:         c.prefetchConcurrency,
+		useStorageApiDisabledClient: !storageRead,
 		queryConfig: bigquery.QueryConfig{
 			DefaultProjectID: c.catalog,
 			DefaultDatasetID: c.dbSchema,

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -55,17 +55,16 @@ import (
 type connectionImpl struct {
 	driverbase.ConnectionImplBase
 
-	authType              string
-	accessToken           string
-	credentials           string
-	clientID              string
-	clientSecret          string
-	refreshToken          string
-	accessTokenEndpoint   string
-	accessTokenServerName string
-	apiEndpoint           string
-
-	endpointUsesReadStorageAPI *bool
+	authType               string
+	accessToken            string
+	credentials            string
+	clientID               string
+	clientSecret           string
+	refreshToken           string
+	accessTokenEndpoint    string
+	accessTokenServerName  string
+	apiEndpoint            string
+	storageReadAPIEndpoint string
 
 	// External-account (Workload Identity Federation) options.
 	externalAccountAudience         string
@@ -94,6 +93,7 @@ type connectionImpl struct {
 
 	client                   *bigquery.Client
 	clientStorageApiDisabled *bigquery.Client // Client without Storage API for queries that use pseudo-columns like _PARTITIONDATE and _PARTITIONTIME
+	storageReadEnabled       bool             // whether EnableStorageReadClient was called on client
 }
 
 func (c *connectionImpl) datasetInProject(projectID, datasetID string) *bigquery.Dataset {
@@ -571,17 +571,14 @@ func (c *connectionImpl) GetTableSchema(ctx context.Context, catalog *string, db
 
 // NewStatement initializes a new statement object tied to this connection
 func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
-	storageRead := c.apiEndpoint == ""
-	if c.endpointUsesReadStorageAPI != nil {
-		storageRead = *c.endpointUsesReadStorageAPI
-	}
+	useStorageApiDisabledClient := c.apiEndpoint != "" || !c.storageReadEnabled
 	return &statement{
 		alloc:                       c.Alloc,
 		cnxn:                        c,
 		parameterMode:               OptionValueQueryParameterModePositional,
 		resultRecordBufferSize:      c.resultRecordBufferSize,
 		prefetchConcurrency:         c.prefetchConcurrency,
-		useStorageApiDisabledClient: !storageRead,
+		useStorageApiDisabledClient: useStorageApiDisabledClient,
 		queryConfig: bigquery.QueryConfig{
 			DefaultProjectID: c.catalog,
 			DefaultDatasetID: c.dbSchema,
@@ -857,12 +854,16 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Cloned rather than reused: WithEndpoint(apiEndpoint) must not leak into the
+	// Storage Read gRPC options built below, since REST and Storage Read have
+	// distinct base URLs.
+	restOptions := authOptions
 	if c.apiEndpoint != "" {
-		// Safe to append: the default endpoint is already assumed by the client, so this only adds a user-specified override.
-		authOptions = append(authOptions, option.WithEndpoint(c.apiEndpoint))
+		restOptions = append(append([]option.ClientOption{}, authOptions...), option.WithEndpoint(c.apiEndpoint))
 	}
 
-	storageReadClient, err := bigquery.NewClient(ctx, c.catalog, authOptions...)
+	storageReadClient, err := bigquery.NewClient(ctx, c.catalog, restOptions...)
 	if err != nil {
 		return err
 	}
@@ -871,16 +872,22 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 		storageReadClient.Location = c.location
 	}
 
-	err = storageReadClient.EnableStorageReadClient(ctx, authOptions...)
-	if err != nil {
-		return err
+	if c.apiEndpoint == "" {
+		storageOptions := authOptions
+		if c.storageReadAPIEndpoint != "" {
+			storageOptions = append(append([]option.ClientOption{}, authOptions...), option.WithEndpoint(c.storageReadAPIEndpoint))
+		}
+		if err := storageReadClient.EnableStorageReadClient(ctx, storageOptions...); err != nil {
+			return err
+		}
+		c.storageReadEnabled = true
 	}
 	c.client = storageReadClient
 
 	// Create a second client without the Storage API enabled
 	// since the Storage API returns null values for pseudo columns, for example _PARTITIONDATE
 	// EnableStorageReadClient should not be invoked for this client
-	client, err := bigquery.NewClient(ctx, c.catalog, authOptions...)
+	client, err := bigquery.NewClient(ctx, c.catalog, restOptions...)
 	if err != nil {
 		return err
 	}

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -30,12 +30,17 @@ import (
 )
 
 const (
-	OptionStringAuthType    = "adbc.bigquery.sql.auth_type"
-	OptionStringAPIEndpoint = "adbc.bigquery.sql.api_endpoint"
-	OptionStringLocation    = "adbc.bigquery.sql.location"
-	OptionStringProjectID   = "adbc.bigquery.sql.project_id"
-	OptionStringDatasetID   = "adbc.bigquery.sql.dataset_id"
-	OptionStringTableID     = "adbc.bigquery.sql.table_id"
+	OptionStringAuthType = "adbc.bigquery.sql.auth_type"
+
+	// Mutually exclusive with OptionStringStorageReadAPIEndpoint: REST and Storage Read
+	// use different base URLs, so a single field can't address both.
+	OptionStringAPIEndpoint            = "adbc.bigquery.sql.api_endpoint"
+	OptionStringStorageReadAPIEndpoint = "adbc.bigquery.sql.storage_read_api_endpoint"
+
+	OptionStringLocation  = "adbc.bigquery.sql.location"
+	OptionStringProjectID = "adbc.bigquery.sql.project_id"
+	OptionStringDatasetID = "adbc.bigquery.sql.dataset_id"
+	OptionStringTableID   = "adbc.bigquery.sql.table_id"
 
 	OptionValueAuthTypeDefault = "adbc.bigquery.sql.auth_type.auth_bigquery"
 
@@ -94,8 +99,6 @@ const (
 	// instead of the Storage Read API. This is required for queries that reference
 	// pseudo-columns like _PARTITIONDATE and _PARTITIONTIME.
 	OptionBoolUseStorageApiDisabledClient = "adbc.bigquery.sql.query.use_storage_api_disabled_client"
-
-	OptionBoolEndpointUsesReadStorageAPI = "adbc.bigquery.sql.query.endpoint_uses_read_storage_api"
 
 	defaultQueryResultBufferSize    = 200
 	defaultQueryPrefetchConcurrency = 10

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -95,6 +95,8 @@ const (
 	// pseudo-columns like _PARTITIONDATE and _PARTITIONTIME.
 	OptionBoolUseStorageApiDisabledClient = "adbc.bigquery.sql.query.use_storage_api_disabled_client"
 
+	OptionBoolEndpointUsesReadStorageAPI = "adbc.bigquery.sql.query.endpoint_uses_read_storage_api"
+
 	defaultQueryResultBufferSize    = 200
 	defaultQueryPrefetchConcurrency = 10
 

--- a/go/adbc/driver/bigquery/record_reader.go
+++ b/go/adbc/driver/bigquery/record_reader.go
@@ -88,11 +88,7 @@ func runQuery(ctx context.Context, query *bigquery.Query, executeUpdate bool, li
 	var arrowIterator bigquery.ArrowIterator
 	useLegacyAPI := ctx.Value(ContextKeyUseStorageApiDisabledClient).(bool)
 	if iter.TotalRows > 0 {
-		if !useLegacyAPI {
-			if !iter.IsAccelerated() {
-				return nil, -1, fmt.Errorf("Storage API is not available for query: %s", jobLink)
-			}
-			// Storage API is available, use it
+		if !useLegacyAPI && iter.IsAccelerated() {
 			if arrowIterator, err = iter.ArrowIterator(); err != nil {
 				if linkFailedJob {
 					return nil, -1, fmt.Errorf("%w (Query: %s)", err, jobLink)
@@ -100,6 +96,9 @@ func runQuery(ctx context.Context, query *bigquery.Query, executeUpdate bool, li
 				return nil, -1, err
 			}
 		} else {
+			// !IsAccelerated() also covers a Storage Read attempt that silently
+			// fell back within the SDK (job.Read never errors on this), not just
+			// the explicit legacy-client case.
 			arrowIterator = newRowBasedArrowIterator(iter, alloc)
 		}
 	} else {


### PR DESCRIPTION
This is dbt-core v1s expected UX

Waiting on UX sign off. This or something like is needed to solve https://github.com/dbt-labs/dbt-core/issues/14617



## What changed

Adding a reflection of an upstream core v2 PR that seeks to default to REST (core like) but give the enterprising user the ability to force their custom endpoints to be designated as Read Storage API (and thus arrow native)