### PR TITLE
feat(adbc/go/driver): api_endpoint now has REST api path append for api_endpoint

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -838,6 +838,8 @@ func (c *connectionImpl) authOptions(ctx context.Context) ([]option.ClientOption
 	return authOptions, nil
 }
 
+const bigQueryRESTPath = "bigquery/v2/"
+
 func (c *connectionImpl) newClient(ctx context.Context) error {
 	if c.catalog == "" {
 		return adbc.Error{
@@ -850,12 +852,20 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Storage Read is gRPC, not REST, and has no "bigquery/v2/" segment.
+	// REST api path is kept separate from authOptions so it isn't broken by the
+	// append below.
+	//
+	// NOTE: Interim until Storage Read gets its own endpoint handling parameter
+	// from foundry merge.
+	restOptions := append([]option.ClientOption{}, authOptions...)
 	if c.apiEndpoint != "" {
-		// Safe to append: the default endpoint is already assumed by the client, so this only adds a user-specified override.
-		authOptions = append(authOptions, option.WithEndpoint(c.apiEndpoint))
+		// WithEndpoint replaces the whole BasePath, default value and all.
+		restOptions = append(restOptions, option.WithEndpoint(c.apiEndpoint+bigQueryRESTPath))
 	}
 
-	storageReadClient, err := bigquery.NewClient(ctx, c.catalog, authOptions...)
+	storageReadClient, err := bigquery.NewClient(ctx, c.catalog, restOptions...)
 	if err != nil {
 		return err
 	}
@@ -873,7 +883,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	// Create a second client without the Storage API enabled
 	// since the Storage API returns null values for pseudo columns, for example _PARTITIONDATE
 	// EnableStorageReadClient should not be invoked for this client
-	client, err := bigquery.NewClient(ctx, c.catalog, authOptions...)
+	client, err := bigquery.NewClient(ctx, c.catalog, restOptions...)
 	if err != nil {
 		return err
 	}

--- a/go/adbc/driver/bigquery/connection_test.go
+++ b/go/adbc/driver/bigquery/connection_test.go
@@ -28,6 +28,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"golang.org/x/oauth2/google/externalaccount"
+	"google.golang.org/api/option"
 )
 
 func TestDatabaseAPIEndpointOption(t *testing.T) {
@@ -44,6 +45,48 @@ func TestDatabaseAPIEndpointOption(t *testing.T) {
 	}
 	if got != "https://bigquery.googleapis.com/bigquery/v2/" {
 		t.Fatalf("expected endpoint to round-trip, got %q", got)
+	}
+}
+
+// TestAPIEndpointRoutesToBigQueryV2Path confirms, through the real
+// google-cloud-go BigQuery client, that a conforming apiEndpoint
+// ("scheme://host[:port]/") is routed under "/bigquery/v2/".
+func TestAPIEndpointRoutesToBigQueryV2Path(t *testing.T) {
+	paths := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case paths <- r.URL.Path:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jobComplete":true,"jobReference":{"jobId":"x"},"schema":{"fields":[]},"rows":[]}`))
+	}))
+	defer srv.Close()
+
+	client, err := bigquery.NewClient(context.Background(), "test-proj",
+		option.WithEndpoint(srv.URL+"/"+bigQueryRESTPath),
+		option.WithHTTPClient(srv.Client()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("bigquery.NewClient returned error: %v", err)
+	}
+	defer client.Close()
+
+	q := client.Query("SELECT 1")
+	it, err := q.Read(context.Background())
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	_ = it
+
+	select {
+	case p := <-paths:
+		if !strings.HasPrefix(p, "/bigquery/v2/") {
+			t.Fatalf("expected request path under /bigquery/v2/, got %q", p)
+		}
+	default:
+		t.Fatal("server did not receive a request")
 	}
 }
 


### PR DESCRIPTION
part 1 of solving: https://github.com/dbt-labs/dbt-core/issues/14615
supercedes: https://github.com/dbt-labs/arrow-adbc/pull/139

## Problem

A BigQuery `api_endpoint` pointing at a proxy or emulator (bare host, no path) routes requests to `.../projects/...` instead of `.../bigquery/v2/projects/...`, because `option.WithEndpoint` replaces the client's entire `BasePath`, and BigQuery's default `BasePath` has `/bigquery/v2/` baked in. 

Proxies/emulators expect the real REST path sometimes which lets to request rejection or misrouting.

## Solution

Let's append that REST api path -- snowflake_connector does this. Weirdly bigquery's own notes on the api_endpoint being a hostname seem to imply it should handle it but it doesn't. 

I didn't want to introduce implicit REST API coercion to the driver. I'd rather give our users a lot of feedback in `dbt-auth` and instead do the bare minimum transform at the driver layer.

## What Changed

Append `bigquery/v2/` to `api_endpoint` before passing it to the REST client's `option.WithEndpoint`. `dbt-auth` validates upfront that `api_endpoint` is exactly `scheme://host[:port]/`. Storage Read (gRPC, a separate service with no REST path) is kept on the unmodified endpoint so it isn't broken by the same append.


  ## Why
Rejecting malformed input beats guessing at it. A driver that silently coerces "close enough" endpoints masks misconfiguration instead of surfacing it. 

Validating strictly upstream (fs) and appending unconditionally downstream (arrow-adbc) keeps each layer's job single-purpose.

  ## Test

- `go test ./driver/bigquery/...` — full suite, including a new end-to-end test against a real `bigquery.NewClient`
  `httptest` server confirming requests route under `/bigquery/v2/`.
- Live A/B against `goccy/bigquery-emulator` behind a Caddy redirectorvia a local `dbt run`:

```shell
    ADBC_REPOSITORY=/path/to/arrow-adbc/go/adbc/pkg DISABLE_CDN_DRIVER_CACHE=1
      dbt run --project-dir <project> --target emulator --select simple_model --no-manage-state
```

Without the fix: `googleapi: got HTTP response code 415` (request hits the wrong listener). 

With the fix: request lands on `/bigquery/v2/...` and reaches real emulator-side query execution.