### PR TITLE
Port `fix(go): CALL <stored_proc> fails with arrow/ipc arrow due to EOF`

### DIFF
--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -74,6 +74,7 @@ type connectionImpl struct {
 
 	activeTransaction     bool
 	useHighPrecision      bool
+	streamRetryEnabled    bool
 	maxTimestampPrecision MaxTimestampPrecision
 }
 
@@ -799,6 +800,7 @@ func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
 		queueSize:             defaultStatementQueueSize,
 		prefetchConcurrency:   defaultPrefetchConcurrency,
 		useHighPrecision:      c.useHighPrecision,
+		streamRetryEnabled:    c.streamRetryEnabled,
 		maxTimestampPrecision: c.maxTimestampPrecision,
 		ingestOptions:         defaultIngestOptions,
 	}
@@ -843,6 +845,19 @@ func (c *connectionImpl) SetOption(key, value string) error {
 			c.useHighPrecision = true
 		case adbc.OptionValueDisabled:
 			c.useHighPrecision = false
+		default:
+			return adbc.Error{
+				Msg:  "[Snowflake] invalid value for option " + key + ": " + value,
+				Code: adbc.StatusInvalidArgument,
+			}
+		}
+		return nil
+	case OptionStreamRetryEnabled:
+		switch value {
+		case adbc.OptionValueEnabled:
+			c.streamRetryEnabled = true
+		case adbc.OptionValueDisabled:
+			c.streamRetryEnabled = false
 		default:
 			return adbc.Error{
 				Msg:  "[Snowflake] invalid value for option " + key + ": " + value,

--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -91,6 +91,16 @@ const (
 	// `microseconds`: Limits the max Timestamp precision to microseconds, which is safe for all values.
 	OptionMaxTimestampPrecision = "adbc.snowflake.sql.client_option.max_timestamp_precision"
 
+	// OptionStreamRetryEnabled controls whether batch reads from Snowflake
+	// use a retry-based approach that buffers entire batches and retries on
+	// failure, or the original streaming approach that reads directly from
+	// the network. When enabled, transient network errors during reads of
+	// batches[1:] will be retried up to a fixed number of attempts; batch[0]
+	// is always read via the original streaming path because its IPC reader
+	// is shared to discover the schema. When disabled, all batches use the
+	// original inline streaming path. Default is disabled.
+	OptionStreamRetryEnabled = "adbc.snowflake.sql.client_option.stream_retry_enabled"
+
 	OptionApplicationName  = "adbc.snowflake.sql.client_option.app_name"
 	OptionSSLSkipVerify    = "adbc.snowflake.sql.client_option.tls_skip_verify"
 	OptionOCSPFailOpenMode = "adbc.snowflake.sql.client_option.ocsp_fail_open_mode"
@@ -306,6 +316,7 @@ func (d *driverImpl) NewDatabaseWithOptionsContext(
 	db := &databaseImpl{
 		DatabaseImplBase:      dbBase,
 		useHighPrecision:      true,
+		streamRetryEnabled:    false,
 		defaultAppName:        defaultAppName,
 		maxTimestampPrecision: Nanoseconds,
 	}

--- a/go/adbc/driver/snowflake/record_reader.go
+++ b/go/adbc/driver/snowflake/record_reader.go
@@ -38,6 +38,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/snowflakedb/gosnowflake"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -558,7 +560,198 @@ type reader struct {
 	cancelFn context.CancelFunc
 }
 
-func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake.ArrowStreamLoader, bufferSize, prefetchConcurrency int, useHighPrecision bool, maxTimestampPrecision MaxTimestampPrecision) (array.RecordReader, error) {
+const defaultStreamMaxRetries = 3
+
+// batchStreamer is the subset of gosnowflake.ArrowStreamBatch needed for reading.
+type batchStreamer interface {
+	GetStream(ctx context.Context) (io.ReadCloser, error)
+}
+
+// countingReadCloser wraps an io.ReadCloser and counts bytes read.
+// Used for diagnosing truncated Arrow IPC streams.
+type countingReadCloser struct {
+	inner     io.ReadCloser
+	bytesRead int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	c.bytesRead += int64(n)
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error {
+	return c.inner.Close()
+}
+
+// readBatchRecords reads all Arrow records from a Snowflake batch with retries.
+// It does not buffer the raw byte stream; instead it reads Arrow IPC messages
+// directly from the network and accumulates transformed record batches in memory.
+// If a stream fails mid-read, all partial records are released and the entire
+// batch is re-downloaded. Records are only returned on full success, preventing
+// partial results from entering channels.
+func readBatchRecords(ctx context.Context, batch batchStreamer, alloc memory.Allocator, transform recordTransformer, maxRetries int) ([]arrow.RecordBatch, error) {
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		recs, err := tryReadBatch(ctx, batch, alloc, transform)
+		if err == nil {
+			trace.SpanFromContext(ctx).AddEvent("readBatchRecords.success", trace.WithAttributes(
+				attribute.Int("attempt", attempt),
+				attribute.Int("records", len(recs)),
+			))
+			return recs, nil
+		}
+		trace.SpanFromContext(ctx).AddEvent("readBatchRecords.failed", trace.WithAttributes(
+			attribute.Int("attempt", attempt),
+			attribute.String("error", err.Error()),
+		))
+		// Release any partial records from the failed attempt
+		for _, r := range recs {
+			r.Release()
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("failed to read Arrow batch after %d attempts: %w", maxRetries+1, lastErr)
+}
+
+func tryReadBatch(ctx context.Context, batch batchStreamer, alloc memory.Allocator, transform recordTransformer) (recs []arrow.RecordBatch, err error) {
+	raw, err := batch.GetStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stream := &countingReadCloser{inner: raw}
+	defer func() {
+		err = errors.Join(err, stream.Close())
+	}()
+
+	rr, err := ipc.NewReader(stream, ipc.WithAllocator(alloc))
+	if err != nil {
+		return nil, fmt.Errorf("ipc.NewReader failed after reading %d bytes: %w", stream.bytesRead, err)
+	}
+	defer rr.Release()
+
+	for rr.Next() && ctx.Err() == nil {
+		rec := rr.RecordBatch()
+		rec, err = transform(ctx, rec)
+		if err != nil {
+			return recs, err
+		}
+		recs = append(recs, rec)
+	}
+	if err = rr.Err(); err != nil {
+		return recs, err
+	}
+	if ctx.Err() != nil {
+		return recs, ctx.Err()
+	}
+	return recs, nil
+}
+
+// readJSONBatches handles the case where GetBatches() returned downloadable
+// chunks that contain JSON data instead of Arrow IPC. This happens with some
+// Snowflake stored procedures that return JSON-format results even when Arrow
+// was requested, and where the inline JSONData() is empty because all data
+// arrives via downloadable chunks.
+//
+// batch0Data contains the already-read bytes for batches[0] (since its stream
+// was consumed during format detection). Remaining batches are read via GetStream.
+func readJSONBatches(ctx context.Context, alloc memory.Allocator, ld gosnowflake.ArrowStreamLoader, batches []gosnowflake.ArrowStreamBatch, batch0Data []byte, maxTimestampPrecision MaxTimestampPrecision, useHighPrecision bool) (array.RecordReader, error) {
+	trace.SpanFromContext(ctx).AddEvent("readJSONBatches", trace.WithAttributes(
+		attribute.Int("batches", len(batches)),
+	))
+
+	schema, err := rowTypesToArrowSchema(ctx, ld, useHighPrecision, maxTimestampPrecision)
+	if err != nil {
+		return nil, adbc.Error{
+			Msg:  err.Error(),
+			Code: adbc.StatusInternal,
+		}
+	}
+
+	if ld.TotalRows() == 0 {
+		return array.NewRecordReader(schema, []arrow.RecordBatch{})
+	}
+
+	bldr := array.NewRecordBuilder(alloc, schema)
+	defer bldr.Release()
+
+	var results []arrow.RecordBatch
+	var rawData [][]*string
+	for batchIdx, b := range batches {
+		var data []byte
+		if batchIdx == 0 {
+			// Use the already-read data for batch[0]
+			data = batch0Data
+		} else {
+			rdr, err := b.GetStream(ctx)
+			if err != nil {
+				return nil, adbc.Error{
+					Msg:  fmt.Sprintf("batch[%d]: GetStream failed: %s", batchIdx, err.Error()),
+					Code: adbc.StatusInternal,
+				}
+			}
+
+			data, err = io.ReadAll(rdr)
+			rdrErr := rdr.Close()
+			if err != nil {
+				return nil, adbc.Error{
+					Msg:  fmt.Sprintf("batch[%d]: ReadAll failed: %s", batchIdx, err.Error()),
+					Code: adbc.StatusInternal,
+				}
+			} else if rdrErr != nil {
+				return nil, rdrErr
+			}
+		}
+
+		trace.SpanFromContext(ctx).AddEvent("readJSONBatches.batch", trace.WithAttributes(
+			attribute.Int("batchIndex", batchIdx),
+			attribute.Int("bytes", len(data)),
+			attribute.Int64("numRows", b.NumRows()),
+		))
+
+		if cap(rawData) >= int(b.NumRows()) {
+			rawData = rawData[:b.NumRows()]
+		} else {
+			rawData = make([][]*string, b.NumRows())
+		}
+		bldr.Reserve(int(b.NumRows()))
+
+		offset, buf := int64(0), bytes.NewReader(data)
+		for i := 0; i < int(b.NumRows()); i++ {
+			dec := json.NewDecoder(buf)
+			if err = dec.Decode(&rawData[i]); err != nil {
+				return nil, adbc.Error{
+					Msg:  fmt.Sprintf("batch[%d] row[%d]: JSON decode failed: %s", batchIdx, i, err.Error()),
+					Code: adbc.StatusInternal,
+				}
+			}
+
+			offset += dec.InputOffset() + 1
+			if _, err = buf.Seek(offset, 0); err != nil {
+				return nil, adbc.Error{
+					Msg:  fmt.Sprintf("batch[%d] row[%d]: seek failed: %s", batchIdx, i, err.Error()),
+					Code: adbc.StatusInternal,
+				}
+			}
+		}
+
+		rec, err := jsonDataToArrow(ctx, bldr, rawData, maxTimestampPrecision)
+		if err != nil {
+			return nil, err
+		}
+		defer rec.Release()
+
+		results = append(results, rec)
+	}
+
+	return array.NewRecordReader(schema, results)
+}
+
+func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake.ArrowStreamLoader, bufferSize, prefetchConcurrency int, useHighPrecision, streamRetryEnabled bool, maxTimestampPrecision MaxTimestampPrecision) (array.RecordReader, error) {
 	batches, err := ld.GetBatches()
 	if err != nil {
 		return nil, errToAdbcErr(adbc.StatusInternal, err)
@@ -692,18 +885,51 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		return rdr, nil
 	}
 
-	r, err := batches[0].GetStream(ctx)
+	trace.SpanFromContext(ctx).AddEvent("newRecordReader", trace.WithAttributes(
+		attribute.Int("batches", len(batches)),
+		attribute.Int64("totalRows", ld.TotalRows()),
+		attribute.Int("jsonDataLen", len(ld.JSONData())),
+	))
+
+	raw0, err := batches[0].GetStream(ctx)
 	if err != nil {
 		return nil, errToAdbcErr(adbc.StatusIO, err)
 	}
 
+	// Use the QueryResultFormatProvider interface to detect when the server
+	// returned JSON-formatted chunks instead of Arrow IPC. Some statements
+	// such as `CALL stored_procedure() RETURNS TABLE(...)` always come back
+	// as JSON regardless of the Arrow request.
+	if fp, ok := ld.(gosnowflake.QueryResultFormatProvider); ok && fp.QueryResultFormat() == "json" {
+		raw0Data, err := io.ReadAll(raw0)
+		_ = raw0.Close()
+		if err != nil {
+			return nil, errToAdbcErr(adbc.StatusIO, fmt.Errorf("batch[0]: ReadAll failed: %w", err))
+		}
+		trace.SpanFromContext(ctx).AddEvent("newRecordReader.jsonFormat", trace.WithAttributes(
+			attribute.Int("batch0Bytes", len(raw0Data)),
+		))
+		return readJSONBatches(ctx, alloc, ld, batches, raw0Data, maxTimestampPrecision, useHighPrecision)
+	}
+
+	r := &countingReadCloser{inner: raw0}
+
 	rr, err := ipc.NewReader(r, ipc.WithAllocator(alloc))
 	if err != nil {
+		trace.SpanFromContext(ctx).AddEvent("newRecordReader.ipcReaderFailed", trace.WithAttributes(
+			attribute.Int64("bytesRead", r.bytesRead),
+			attribute.String("error", err.Error()),
+		))
+		_ = r.Close()
 		return nil, adbc.Error{
-			Msg:  err.Error(),
+			Msg:  fmt.Sprintf("batch[0]: ipc.NewReader failed after reading %d bytes: %s", r.bytesRead, err.Error()),
 			Code: adbc.StatusInvalidState,
 		}
 	}
+	trace.SpanFromContext(ctx).AddEvent("newRecordReader.schemaOK", trace.WithAttributes(
+		attribute.Int64("bytesRead", r.bytesRead),
+		attribute.String("schema", rr.Schema().String()),
+	))
 
 	var recTransform recordTransformer
 	rdr.schema, recTransform = getTransformer(rr.Schema(), ld, useHighPrecision, maxTimestampPrecision)
@@ -732,40 +958,88 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 
 	lastChannelIndex := len(chs) - 1
 	go func() {
-		for i, b := range batches[1:] {
-			batch, batchIdx := b, i+1
+		for i := range batches[1:] {
+			batch, batchIdx := &batches[i+1], i+1
 			chs[batchIdx] = make(chan arrow.RecordBatch, bufferSize)
-			group.Go(func() (err error) {
-				// close channels (except the last) so that Next can move on to the next channel properly
-				if batchIdx != lastChannelIndex {
-					defer close(chs[batchIdx])
-				}
+			group.Go(func(batch batchStreamer, batchIdx int) func() error {
+				return func() (err error) {
+					// close channels (except the last) so that Next can move on to the next channel properly
+					if batchIdx != lastChannelIndex {
+						defer close(chs[batchIdx])
+					}
 
-				rdr, err := batch.GetStream(ctx)
-				if err != nil {
-					return err
-				}
-				defer func() {
-					err = errors.Join(err, rdr.Close())
-				}()
+					if streamRetryEnabled {
+						recs, err := readBatchRecords(ctx, batch, alloc, recTransform, defaultStreamMaxRetries)
+						if err != nil {
+							trace.SpanFromContext(ctx).AddEvent("batch.readBatchRecords.failed", trace.WithAttributes(
+								attribute.Int("batchIndex", batchIdx),
+								attribute.String("error", err.Error()),
+							))
+							return err
+						}
+						trace.SpanFromContext(ctx).AddEvent("batch.readBatchRecords.success", trace.WithAttributes(
+							attribute.Int("batchIndex", batchIdx),
+							attribute.Int("records", len(recs)),
+						))
+						for i, rec := range recs {
+							select {
+							case chs[batchIdx] <- rec:
+								recs[i] = nil // ownership transferred to channel
+							case <-ctx.Done():
+								rec.Release()
+								// Release only unsent records
+								for _, r := range recs[i+1:] {
+									if r != nil {
+										r.Release()
+									}
+								}
+								return ctx.Err()
+							}
+						}
+						return nil
+					}
 
-				rr, err := ipc.NewReader(rdr, ipc.WithAllocator(alloc))
-				if err != nil {
-					return err
-				}
-				defer rr.Release()
-
-				for rr.Next() && ctx.Err() == nil {
-					rec := rr.RecordBatch()
-					rec, err = recTransform(ctx, rec)
+					// Original streaming path: read directly from stream without buffering
+					rawStream, err := batch.GetStream(ctx)
 					if err != nil {
+						trace.SpanFromContext(ctx).AddEvent("batch.GetStream.failed", trace.WithAttributes(
+							attribute.Int("batchIndex", batchIdx),
+							attribute.String("error", err.Error()),
+						))
 						return err
 					}
-					chs[batchIdx] <- rec
-				}
+					countingStream := &countingReadCloser{inner: rawStream}
+					defer func() {
+						err = errors.Join(err, countingStream.Close())
+					}()
 
-				return rr.Err()
-			})
+					rr, err := ipc.NewReader(countingStream, ipc.WithAllocator(alloc))
+					if err != nil {
+						trace.SpanFromContext(ctx).AddEvent("batch.ipcReader.failed", trace.WithAttributes(
+							attribute.Int("batchIndex", batchIdx),
+							attribute.Int64("bytesRead", countingStream.bytesRead),
+							attribute.String("error", err.Error()),
+						))
+						return fmt.Errorf("batch[%d]: ipc.NewReader failed after reading %d bytes: %w", batchIdx, countingStream.bytesRead, err)
+					}
+					defer rr.Release()
+
+					for rr.Next() && ctx.Err() == nil {
+						rec := rr.RecordBatch()
+						rec, err = recTransform(ctx, rec)
+						if err != nil {
+							return err
+						}
+						select {
+						case chs[batchIdx] <- rec:
+						case <-ctx.Done():
+							rec.Release()
+							return ctx.Err()
+						}
+					}
+					return rr.Err()
+				}
+			}(batch, batchIdx))
 		}
 
 		// place this here so that we always clean up, but they can't be in a

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -83,6 +83,7 @@ type databaseImpl struct {
 	refreshToken string
 
 	useHighPrecision      bool
+	streamRetryEnabled    bool
 	maxTimestampPrecision MaxTimestampPrecision
 	defaultAppName        string
 }
@@ -168,6 +169,11 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.refreshToken, nil
 	case OptionUseHighPrecision:
 		if d.useHighPrecision {
+			return adbc.OptionValueEnabled, nil
+		}
+		return adbc.OptionValueDisabled, nil
+	case OptionStreamRetryEnabled:
+		if d.streamRetryEnabled {
 			return adbc.OptionValueEnabled, nil
 		}
 		return adbc.OptionValueDisabled, nil
@@ -528,6 +534,18 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 				Code: adbc.StatusInvalidArgument,
 			}
 		}
+	case OptionStreamRetryEnabled:
+		switch v {
+		case adbc.OptionValueEnabled:
+			d.streamRetryEnabled = true
+		case adbc.OptionValueDisabled:
+			d.streamRetryEnabled = false
+		default:
+			return adbc.Error{
+				Msg:  fmt.Sprintf("Invalid value for database option '%s': '%s'", OptionStreamRetryEnabled, v),
+				Code: adbc.StatusInvalidArgument,
+			}
+		}
 	case OptionMaxTimestampPrecision:
 		switch v {
 		case OptionValueNanoseconds, OptionValueNanosecondsNoOverflow, OptionValueMicroseconds:
@@ -572,6 +590,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbcConnection adbc.Connection
 		// SetOption(OptionUseHighPrecision, adbc.OptionValueDisabled) to
 		// get Int64/Float64 instead
 		useHighPrecision:      d.useHighPrecision,
+		streamRetryEnabled:    d.streamRetryEnabled,
 		maxTimestampPrecision: d.maxTimestampPrecision,
 		ConnectionImplBase:    driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
 	}

--- a/go/adbc/driver/snowflake/statement.go
+++ b/go/adbc/driver/snowflake/statement.go
@@ -56,6 +56,7 @@ type statement struct {
 	queueSize             int
 	prefetchConcurrency   int
 	useHighPrecision      bool
+	streamRetryEnabled    bool
 	maxTimestampPrecision MaxTimestampPrecision
 
 	query         string
@@ -233,6 +234,18 @@ func (st *statement) SetOption(key string, val string) error {
 			st.useHighPrecision = true
 		case adbc.OptionValueDisabled:
 			st.useHighPrecision = false
+		default:
+			return adbc.Error{
+				Msg:  fmt.Sprintf("[Snowflake] invalid statement option %s=%s", key, val),
+				Code: adbc.StatusInvalidArgument,
+			}
+		}
+	case OptionStreamRetryEnabled:
+		switch val {
+		case adbc.OptionValueEnabled:
+			st.streamRetryEnabled = true
+		case adbc.OptionValueDisabled:
+			st.streamRetryEnabled = false
 		default:
 			return adbc.Error{
 				Msg:  fmt.Sprintf("[Snowflake] invalid statement option %s=%s", key, val),
@@ -534,7 +547,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (reader array.RecordReade
 					return nil, err
 				}
 
-				reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.maxTimestampPrecision)
+				reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.streamRetryEnabled, st.maxTimestampPrecision)
 				return reader, err
 			},
 			currentBatch: st.bound,
@@ -559,7 +572,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (reader array.RecordReade
 		return
 	}
 
-	reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.maxTimestampPrecision)
+	reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.streamRetryEnabled, st.maxTimestampPrecision)
 	nRows = loader.TotalRows()
 	return
 }

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -70,7 +70,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 )
 
-replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.10
+replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.11
 
 replace github.com/databricks/databricks-sql-go => github.com/dbt-labs/databricks-sql-go v1.19.1
 

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dbt-labs/databricks-sql-go v1.19.1 h1:kQWYSmDv1piGsUTpctyILYMRgZXNsFedZo/1QmWzxcA=
 github.com/dbt-labs/databricks-sql-go v1.19.1/go.mod h1:TGAVzvXadeKI8me3nKBa/2phLNnyWR6OolYq6iYbN3E=
-github.com/dbt-labs/gosnowflake v1.17.10 h1:HLLXfiU0yMDhsDsKBPIZBWAVFL/LIJzkasx9tY0WXbM=
-github.com/dbt-labs/gosnowflake v1.17.10/go.mod h1:WPSInfc1Uemdhr6PQbPp0C7LW7j4u6pIe/+g2QuOwkQ=
+github.com/dbt-labs/gosnowflake v1.17.11 h1:ozhz6/zjPS0mVXC54VIYMWNYYsNhUcjcP4fMs0rnjrM=
+github.com/dbt-labs/gosnowflake v1.17.11/go.mod h1:WPSInfc1Uemdhr6PQbPp0C7LW7j4u6pIe/+g2QuOwkQ=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
This PR is a port of https://github.com/adbc-drivers/snowflake/pull/114/

It depends on a port of a commit from gosnowflake 2 to our fork of
gosnowflake 1.17: https://github.com/dbt-labs/gosnowflake/pull/33

I tested it locally with `cargo adbc`
<img width="1078" height="1263" alt="image" src="https://github.com/user-attachments/assets/5fc801de-d7fd-42d3-8e56-edb1c56f60f5" />

