### PR TITLE
fix(go/adbc/driver/bigquery): recover from 409 on duplicate job insert

### DIFF
--- a/go/adbc/driver/bigquery/record_reader.go
+++ b/go/adbc/driver/bigquery/record_reader.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -34,7 +35,9 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
 
@@ -64,8 +67,16 @@ func checkContext(ctx context.Context, maybeErr error) error {
 	return ctx.Err()
 }
 
-func runQuery(ctx context.Context, query *bigquery.Query, executeUpdate bool, linkFailedJob bool, alloc memory.Allocator) (bigquery.ArrowIterator, int64, error) {
+func runQuery(ctx context.Context, client *bigquery.Client, query *bigquery.Query, executeUpdate bool, linkFailedJob bool, alloc memory.Allocator) (bigquery.ArrowIterator, int64, error) {
+	// A Query can be reused for bound parameter rows. Give every execution its
+	// own ID, then reuse that ID only to recover a duplicate insert response.
+	query.JobID = "adbc-" + uuid.NewString()
+
 	job, err := query.Run(ctx)
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusConflict {
+		job, err = client.JobFromIDLocation(ctx, query.JobID, query.Location)
+	}
 	if err != nil {
 		return nil, -1, err
 	}
@@ -134,8 +145,8 @@ func getQueryParameter(values arrow.RecordBatch, row int, parameterMode string) 
 	return parameters, nil
 }
 
-func runPlainQuery(ctx context.Context, query *bigquery.Query, alloc memory.Allocator, resultRecordBufferSize int, linkFailedJob bool) (bigqueryRdr *reader, totalRows int64, err error) {
-	arrowIterator, totalRows, err := runQuery(ctx, query, false, linkFailedJob, alloc)
+func runPlainQuery(ctx context.Context, client *bigquery.Client, query *bigquery.Query, alloc memory.Allocator, resultRecordBufferSize int, linkFailedJob bool) (bigqueryRdr *reader, totalRows int64, err error) {
+	arrowIterator, totalRows, err := runQuery(ctx, client, query, false, linkFailedJob, alloc)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -181,7 +192,7 @@ func runPlainQuery(ctx context.Context, query *bigquery.Query, alloc memory.Allo
 	return bigqueryRdr, totalRows, nil
 }
 
-func queryRecordWithSchemaCallback(ctx context.Context, group *errgroup.Group, query *bigquery.Query, rec arrow.RecordBatch, ch chan arrow.RecordBatch, parameterMode string, alloc memory.Allocator, rdrSchema func(schema *arrow.Schema), linkFailedJob bool) (int64, error) {
+func queryRecordWithSchemaCallback(ctx context.Context, group *errgroup.Group, client *bigquery.Client, query *bigquery.Query, rec arrow.RecordBatch, ch chan arrow.RecordBatch, parameterMode string, alloc memory.Allocator, rdrSchema func(schema *arrow.Schema), linkFailedJob bool) (int64, error) {
 	totalRows := int64(-1)
 	for i := 0; i < int(rec.NumRows()); i++ {
 		parameters, err := getQueryParameter(rec, i, parameterMode)
@@ -192,7 +203,7 @@ func queryRecordWithSchemaCallback(ctx context.Context, group *errgroup.Group, q
 			query.Parameters = parameters
 		}
 
-		arrowIterator, rows, err := runQuery(ctx, query, false, linkFailedJob, alloc)
+		arrowIterator, rows, err := runQuery(ctx, client, query, false, linkFailedJob, alloc)
 		if err != nil {
 			return -1, err
 		}
@@ -218,9 +229,9 @@ func queryRecordWithSchemaCallback(ctx context.Context, group *errgroup.Group, q
 
 // kicks off a goroutine for each endpoint and returns a reader which
 // gathers all of the records as they come in.
-func newRecordReader(ctx context.Context, query *bigquery.Query, boundParameters array.RecordReader, parameterMode string, alloc memory.Allocator, resultRecordBufferSize, prefetchConcurrency int, linkFailedJob bool) (bigqueryRdr *reader, totalRows int64, err error) {
+func newRecordReader(ctx context.Context, client *bigquery.Client, query *bigquery.Query, boundParameters array.RecordReader, parameterMode string, alloc memory.Allocator, resultRecordBufferSize, prefetchConcurrency int, linkFailedJob bool) (bigqueryRdr *reader, totalRows int64, err error) {
 	if boundParameters == nil {
-		return runPlainQuery(ctx, query, alloc, resultRecordBufferSize, linkFailedJob)
+		return runPlainQuery(ctx, client, query, alloc, resultRecordBufferSize, linkFailedJob)
 	}
 	defer boundParameters.Release()
 
@@ -256,7 +267,7 @@ func newRecordReader(ctx context.Context, query *bigquery.Query, boundParameters
 		// Each call to Record() on the record reader is allowed to release the previous record
 		// and since we're doing this sequentially
 		// we don't need to call rec.Retain() here and call call rec.Release() in queryRecordWithSchemaCallback
-		batchRows, err := queryRecordWithSchemaCallback(ctx, group, query, rec, ch, parameterMode, alloc, func(schema *arrow.Schema) {
+		batchRows, err := queryRecordWithSchemaCallback(ctx, group, client, query, rec, ch, parameterMode, alloc, func(schema *arrow.Schema) {
 			bigqueryRdr.schema = schema
 		}, linkFailedJob)
 		if err != nil {

--- a/go/adbc/driver/bigquery/record_reader_test.go
+++ b/go/adbc/driver/bigquery/record_reader_test.go
@@ -19,11 +19,96 @@ package bigquery
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"google.golang.org/api/option"
 )
+
+func TestRunQueryRecoversExistingJobAfterDuplicateInsert(t *testing.T) {
+	const (
+		projectID = "test-project"
+		location  = "us-west1"
+	)
+
+	submittedJobIDs := make(map[string]struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/bigquery/v2/projects/test-project/jobs":
+			var submitted struct {
+				JobReference struct {
+					JobID string `json:"jobId"`
+				} `json:"jobReference"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&submitted); err != nil {
+				t.Fatalf("decode submitted job: %v", err)
+			}
+			submittedJobID := submitted.JobReference.JobID
+			if submittedJobID == "" {
+				t.Fatal("expected the driver to submit a job ID")
+			}
+			if _, exists := submittedJobIDs[submittedJobID]; exists {
+				t.Errorf("expected a distinct job ID for each execution, got %q twice", submittedJobID)
+			}
+			submittedJobIDs[submittedJobID] = struct{}{}
+
+			w.WriteHeader(http.StatusConflict)
+			_, _ = fmt.Fprint(w, `{"error":{"code":409,"message":"Already Exists: Job duplicate"}}`)
+
+		case r.Method == http.MethodGet && r.URL.Path[:len("/bigquery/v2/projects/test-project/jobs/")] == "/bigquery/v2/projects/test-project/jobs/":
+			submittedJobID := r.URL.Path[len("/bigquery/v2/projects/test-project/jobs/"):]
+			_, _ = fmt.Fprintf(w, `{"configuration":{"query":{"query":"SELECT 1","useLegacySql":false}},"jobReference":{"projectId":%q,"location":%q,"jobId":%q},"status":{"state":"DONE"}}`, projectID, location, submittedJobID)
+
+		case r.Method == http.MethodGet && r.URL.Path[:len("/bigquery/v2/projects/test-project/queries/")] == "/bigquery/v2/projects/test-project/queries/":
+			submittedJobID := r.URL.Path[len("/bigquery/v2/projects/test-project/queries/"):]
+			_, _ = fmt.Fprintf(w, `{"jobComplete":true,"jobReference":{"projectId":%q,"location":%q,"jobId":%q},"schema":{"fields":[]},"totalRows":"0"}`, projectID, location, submittedJobID)
+
+		default:
+			t.Fatalf("unexpected BigQuery request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := bigquery.NewClient(
+		context.Background(),
+		projectID,
+		option.WithEndpoint(srv.URL+"/bigquery/v2/"),
+		option.WithHTTPClient(srv.Client()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("create BigQuery client: %v", err)
+	}
+	defer client.Close()
+
+	query := client.Query("SELECT 1")
+	query.Location = location
+
+	ctx := context.WithValue(context.Background(), ContextKeyUseStorageApiDisabledClient, false)
+	for range 2 {
+		iterator, rows, err := runQuery(ctx, client, query, false, false, memory.DefaultAllocator)
+		if err != nil {
+			t.Fatalf("run query after duplicate insert: %v", err)
+		}
+		if iterator == nil {
+			t.Fatal("expected an iterator for the recovered job")
+		}
+		if rows != 0 {
+			t.Fatalf("expected zero rows, got %d", rows)
+		}
+	}
+	if len(submittedJobIDs) != 2 {
+		t.Fatalf("expected two distinct submitted job IDs, got %d", len(submittedJobIDs))
+	}
+}
 
 func TestEmptyArrowIteratorNext(t *testing.T) {
 	iter := emptyArrowIterator{}

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -582,7 +582,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, int6
 	}
 
 	ctx = context.WithValue(ctx, ContextKeyUseStorageApiDisabledClient, st.useStorageApiDisabledClient)
-	return newRecordReader(ctx, st.query(), rdr, st.parameterMode, st.cnxn.Alloc, st.resultRecordBufferSize, st.prefetchConcurrency, st.linkFailedJob)
+	return newRecordReader(ctx, st.queryClient(), st.query(), rdr, st.parameterMode, st.cnxn.Alloc, st.resultRecordBufferSize, st.prefetchConcurrency, st.linkFailedJob)
 }
 
 // ExecuteUpdate executes a statement that does not generate a result
@@ -594,7 +594,7 @@ func (st *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 	}
 
 	if boundParameters == nil {
-		_, totalRows, err := runQuery(ctx, st.query(), true, st.linkFailedJob, st.alloc)
+		_, totalRows, err := runQuery(ctx, st.queryClient(), st.query(), true, st.linkFailedJob, st.alloc)
 		if err != nil {
 			return -1, err
 		}
@@ -612,7 +612,7 @@ func (st *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 					st.queryConfig.Parameters = parameters
 				}
 
-				_, currentRows, err := runQuery(ctx, st.query(), true, st.linkFailedJob, st.alloc)
+				_, currentRows, err := runQuery(ctx, st.queryClient(), st.query(), true, st.linkFailedJob, st.alloc)
 				if err != nil {
 					return -1, err
 				}
@@ -661,14 +661,16 @@ func (st *statement) SetSubstraitPlan(plan []byte) error {
 }
 
 func (st *statement) query() *bigquery.Query {
-	var query *bigquery.Query
-	if st.useStorageApiDisabledClient && st.cnxn.clientStorageApiDisabled != nil {
-		query = st.cnxn.clientStorageApiDisabled.Query("")
-	} else {
-		query = st.cnxn.client.Query("")
-	}
+	query := st.queryClient().Query("")
 	query.QueryConfig = st.queryConfig
 	return query
+}
+
+func (st *statement) queryClient() *bigquery.Client {
+	if st.useStorageApiDisabledClient && st.cnxn.clientStorageApiDisabled != nil {
+		return st.cnxn.clientStorageApiDisabled
+	}
+	return st.cnxn.client
 }
 
 func arrowDataTypeToTypeKind(field arrow.Field, value arrow.Array) (bigquery.StandardSQLDataType, error) {


### PR DESCRIPTION
## Problem

When BigQuery returns **HTTP 409 Already Exists** on job submission, the driver was surfacing the error to the caller instead of attaching to the already-created job and reading its results. This caused intermittent failures when query submission was retried after a transient timeout — the job existed on BigQuery's side but the driver didn't know how to find it.

Tracked in: dbt-labs/fs#12677  
Upstream issue: apache/arrow-adbc#4660

## Fix

**`record_reader.go`**
- Assign a driver-owned UUID job ID (`adbc-<uuid>`) before every `query.Run()` call, unconditionally. (Previously the ID was assigned once and reused, which broke bound-parameter execution where the same `Query` object is called for each row.)
- After `query.Run()`, check whether the error is a `*googleapi.Error` with code 409. If so, call `client.JobFromIDLocation(ctx, query.JobID, query.Location)` to attach to the already-created job and continue reading results.
- Thread `*bigquery.Client` through `runQuery` / `runPlainQuery` / `queryRecordWithSchemaCallback` / `newRecordReader` so the recovery call has access to the client.

**`statement.go`**
- Extract `queryClient()` helper (was duplicated inline in `query()`).
- Pass `st.queryClient()` at all three call sites that invoke `runQuery` / `newRecordReader`.

## Test

`TestRunQueryRecoversExistingJobAfterDuplicateInsert` in `record_reader_test.go`:
- Spins up an `httptest.Server` that always returns 409 on job submission.
- Runs `runQuery` twice on the same `Query` object (simulating bound-parameter reuse).
- Verifies: both executions succeed, each submission used a **distinct** job ID, and both return the expected zero-row result.

```
ok  github.com/apache/arrow-adbc/go/adbc/driver/bigquery  1.191s
```

## Files changed

| File | Change |
|------|--------|
| `go/adbc/driver/bigquery/record_reader.go` | 409 recovery, per-execution UUID, thread `client` |
| `go/adbc/driver/bigquery/statement.go` | `queryClient()` helper, pass client at call sites |
| `go/adbc/driver/bigquery/record_reader_test.go` | regression test |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)