### PR TITLE
databricks: add connect_timeout option with 200s default

### DIFF
--- a/go/adbc/driver/databricks/database.go
+++ b/go/adbc/driver/databricks/database.go
@@ -358,10 +358,7 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		}
 		return "", nil
 	case OptionConnectTimeout:
-		if d.hasConnectTimeout() {
-			return d.connectTimeout.String(), nil
-		}
-		return "", nil
+		return d.connectTimeout.String(), nil
 	case OptionMaxRows:
 		if d.maxRows > 0 {
 			return strconv.Itoa(d.maxRows), nil

--- a/go/adbc/driver/databricks/database.go
+++ b/go/adbc/driver/databricks/database.go
@@ -62,6 +62,10 @@ type databaseImpl struct {
 	schema         string
 	user_agent     string
 
+	// Connection establishment timeout: bounds OpenSession and retries a
+	// cold-starting warehouse until the deadline. 0 = single attempt (prior behavior).
+	connectTimeout time.Duration
+
 	// Query options
 	queryTimeout        time.Duration
 	maxRows             int
@@ -197,6 +201,10 @@ func (d *databaseImpl) resolveConnectionOptions() ([]dbsql.ConnOption, error) {
 
 	if d.queryTimeout > 0 {
 		opts = append(opts, dbsql.WithTimeout(d.queryTimeout))
+	}
+
+	if d.connectTimeout > 0 {
+		opts = append(opts, dbsql.WithConnectTimeout(d.connectTimeout))
 	}
 
 	if d.maxRows > 0 {
@@ -343,6 +351,11 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 			return d.queryTimeout.String(), nil
 		}
 		return "", nil
+	case OptionConnectTimeout:
+		if d.connectTimeout > 0 {
+			return d.connectTimeout.String(), nil
+		}
+		return "", nil
 	case OptionMaxRows:
 		if d.maxRows > 0 {
 			return strconv.Itoa(d.maxRows), nil
@@ -458,6 +471,17 @@ func (d *databaseImpl) SetOption(key, value string) error {
 				}
 			}
 			d.queryTimeout = timeout
+		}
+	case OptionConnectTimeout:
+		if value != "" {
+			timeout, err := time.ParseDuration(value)
+			if err != nil {
+				return adbc.Error{
+					Code: adbc.StatusInvalidArgument,
+					Msg:  fmt.Sprintf("invalid connect timeout: %v", err),
+				}
+			}
+			d.connectTimeout = timeout
 		}
 	case OptionMaxRows:
 		if value != "" {

--- a/go/adbc/driver/databricks/database.go
+++ b/go/adbc/driver/databricks/database.go
@@ -98,6 +98,12 @@ type databaseImpl struct {
 	sessionParams map[string]string
 }
 
+// hasConnectTimeout reports whether an explicit connect timeout is configured,
+// so resolveConnectionOptions and GetOption agree on what "set" means.
+func (d *databaseImpl) hasConnectTimeout() bool {
+	return d.connectTimeout > 0
+}
+
 func (d *databaseImpl) resolveConnectionOptions() ([]dbsql.ConnOption, error) {
 	if d.serverHostname == "" {
 		return nil, adbc.Error{
@@ -203,7 +209,7 @@ func (d *databaseImpl) resolveConnectionOptions() ([]dbsql.ConnOption, error) {
 		opts = append(opts, dbsql.WithTimeout(d.queryTimeout))
 	}
 
-	if d.connectTimeout > 0 {
+	if d.hasConnectTimeout() {
 		opts = append(opts, dbsql.WithConnectTimeout(d.connectTimeout))
 	}
 
@@ -352,7 +358,7 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		}
 		return "", nil
 	case OptionConnectTimeout:
-		if d.connectTimeout > 0 {
+		if d.hasConnectTimeout() {
 			return d.connectTimeout.String(), nil
 		}
 		return "", nil

--- a/go/adbc/driver/databricks/database.go
+++ b/go/adbc/driver/databricks/database.go
@@ -487,6 +487,12 @@ func (d *databaseImpl) SetOption(key, value string) error {
 					Msg:  fmt.Sprintf("invalid connect timeout: %v", err),
 				}
 			}
+			if timeout <= 0 {
+				return adbc.Error{
+					Code: adbc.StatusInvalidArgument,
+					Msg:  fmt.Sprintf("connect timeout must be positive: %v", timeout),
+				}
+			}
 			d.connectTimeout = timeout
 		}
 	case OptionMaxRows:

--- a/go/adbc/driver/databricks/database_test.go
+++ b/go/adbc/driver/databricks/database_test.go
@@ -21,10 +21,13 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestDatabase(t *testing.T) *databaseImpl {
@@ -71,4 +74,54 @@ func TestConcurrentOpen(t *testing.T) {
 	for i, err := range errs {
 		assert.Error(t, err, "goroutine %d should fail (no real server)", i)
 	}
+}
+
+// TestSetOptionConnectTimeout verifies the connect-timeout option parses a Go
+// duration, is stored on the database impl and surfaced via GetOption, and that
+// an unparseable value is rejected.
+func TestSetOptionConnectTimeout(t *testing.T) {
+	db := newTestDatabase(t)
+
+	require.NoError(t, db.SetOption(OptionConnectTimeout, "600s"))
+	assert.Equal(t, 600*time.Second, db.connectTimeout)
+
+	got, err := db.GetOption(OptionConnectTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, (600 * time.Second).String(), got)
+
+	err = db.SetOption(OptionConnectTimeout, "not-a-duration")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid connect timeout")
+}
+
+// TestResolveConnectionOptionsConnectTimeout verifies the connect-timeout option
+// is added to the databricks-sql-go connector options only when set. (The internal
+// config package can't be imported here, so we assert on the presence of the extra
+// ConnOption rather than its applied effect.)
+func TestResolveConnectionOptionsConnectTimeout(t *testing.T) {
+	base := newTestDatabase(t)
+	baseOpts, err := base.resolveConnectionOptions()
+	require.NoError(t, err)
+
+	withTimeout := newTestDatabase(t)
+	withTimeout.connectTimeout = 600 * time.Second
+	timeoutOpts, err := withTimeout.resolveConnectionOptions()
+	require.NoError(t, err)
+
+	assert.Equal(t, len(baseOpts)+1, len(timeoutOpts),
+		"setting connectTimeout should add exactly one connector option")
+}
+
+// TestDefaultConnectTimeout verifies a database constructed via the driver gets
+// the default connect timeout when the caller does not set OptionConnectTimeout.
+func TestDefaultConnectTimeout(t *testing.T) {
+	drv := NewDriver(memory.DefaultAllocator)
+	db, err := drv.NewDatabase(map[string]string{})
+	require.NoError(t, err)
+
+	gs, ok := db.(adbc.GetSetOptions)
+	require.True(t, ok)
+	got, err := gs.GetOption(OptionConnectTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultConnectTimeout.String(), got)
 }

--- a/go/adbc/driver/databricks/driver.go
+++ b/go/adbc/driver/databricks/driver.go
@@ -49,6 +49,7 @@ const (
 	OptionCatalog        = "databricks.catalog"
 	OptionSchema         = "databricks.schema"
 	OptionUserAgent      = "databricks.user_agent"
+
 	// OptionConnectTimeout bounds establishing a session and retries an
 	// unavailable (cold-starting) warehouse until the deadline. Duration string,
 	// e.g. "600s". Unset/0 keeps the prior single-attempt behavior.
@@ -94,6 +95,7 @@ const (
 	DefaultPort                   = 443
 	DefaultSSLMode                = "require"
 	DefaultExternalBrowserTimeout = 1 * time.Minute
+
 	// DefaultConnectTimeout bounds session establishment (and retries a
 	// cold-starting warehouse) when the caller does not set OptionConnectTimeout.
 	DefaultConnectTimeout = 200 * time.Second

--- a/go/adbc/driver/databricks/driver.go
+++ b/go/adbc/driver/databricks/driver.go
@@ -49,6 +49,10 @@ const (
 	OptionCatalog        = "databricks.catalog"
 	OptionSchema         = "databricks.schema"
 	OptionUserAgent      = "databricks.user_agent"
+	// OptionConnectTimeout bounds establishing a session and retries an
+	// unavailable (cold-starting) warehouse until the deadline. Duration string,
+	// e.g. "600s". Unset/0 keeps the prior single-attempt behavior.
+	OptionConnectTimeout = "databricks.connect_timeout"
 
 	// Query options
 	OptionQueryTimeout        = "databricks.query.timeout"
@@ -90,6 +94,9 @@ const (
 	DefaultPort                   = 443
 	DefaultSSLMode                = "require"
 	DefaultExternalBrowserTimeout = 1 * time.Minute
+	// DefaultConnectTimeout bounds session establishment (and retries a
+	// cold-starting warehouse) when the caller does not set OptionConnectTimeout.
+	DefaultConnectTimeout = 200 * time.Second
 )
 
 var (
@@ -142,6 +149,7 @@ func (d *driverImpl) NewDatabaseWithContext(ctx context.Context, opts map[string
 		DatabaseImplBase: dbBase,
 		port:             DefaultPort,
 		sslMode:          DefaultSSLMode,
+		connectTimeout:   DefaultConnectTimeout,
 	}
 
 	if err := db.SetOptions(opts); err != nil {

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -74,7 +74,7 @@ require (
 
 replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.11
 
-replace github.com/databricks/databricks-sql-go => github.com/dbt-labs/databricks-sql-go v1.19.1
+replace github.com/databricks/databricks-sql-go => github.com/dbt-labs/databricks-sql-go v1.19.2-0.20260805120614-bf42a125099e
 
 require (
 	cloud.google.com/go v0.121.6

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dbt-labs/databricks-sql-go v1.19.1 h1:kQWYSmDv1piGsUTpctyILYMRgZXNsFedZo/1QmWzxcA=
-github.com/dbt-labs/databricks-sql-go v1.19.1/go.mod h1:TGAVzvXadeKI8me3nKBa/2phLNnyWR6OolYq6iYbN3E=
+github.com/dbt-labs/databricks-sql-go v1.19.2-0.20260805120614-bf42a125099e h1:5hrc6xMl13u39DjmXasDJs2rVLlTuYyIHCpqspPzEoA=
+github.com/dbt-labs/databricks-sql-go v1.19.2-0.20260805120614-bf42a125099e/go.mod h1:TGAVzvXadeKI8me3nKBa/2phLNnyWR6OolYq6iYbN3E=
 github.com/dbt-labs/gosnowflake v1.17.11 h1:ozhz6/zjPS0mVXC54VIYMWNYYsNhUcjcP4fMs0rnjrM=
 github.com/dbt-labs/gosnowflake v1.17.11/go.mod h1:WPSInfc1Uemdhr6PQbPp0C7LW7j4u6pIe/+g2QuOwkQ=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=


### PR DESCRIPTION
## What

Adds a `databricks.connect_timeout` ADBC option (`OptionConnectTimeout`) to the Databricks driver: parsed as a Go duration in `SetOption`, surfaced in `GetOption`, and threaded to databricks-sql-go via `dbsql.WithConnectTimeout`. Defaults to **200s** (`DefaultConnectTimeout`) when the caller sets nothing.

## Why

On a cold-starting (non-serverless) warehouse, `db.PingContext` -> `OpenSession` is retried only up to the driver's fixed `RetryMax`, so a slow cold start fails with `dbt1308: ... context deadline exceeded` and there is no way to wait longer. This exposes a real, configurable connection-establishment deadline. See dbt-labs/dbt-core#14529.

## Behavior

- Unset: 200s default connection-establishment budget (retries a cold-starting warehouse until then).
- Set via `databricks.connect_timeout` (e.g. `"600s"`): overrides the default.
- Transient failures (HTTP 503) retry until the deadline; non-retryable failures fail fast (handled in databricks-sql-go).

## Tests

`TestSetOptionConnectTimeout`, `TestResolveConnectionOptionsConnectTimeout`, `TestDefaultConnectTimeout`.

## Dependency / ordering

Depends on **dbt-labs/databricks-sql-go#5** (adds `WithConnectTimeout`). The `go.mod` bump to a released databricks-sql-go tag will follow once that PR is merged and tagged; until then CI here will not compile against the pinned `v1.19.1`. Kept as a draft for that reason.

Part of the dbt-core#14529 chain: databricks-sql-go#5 -> **this** -> dbt-labs/fs.