### PR TITLE
feat(go/adbc/driver/snowflake): support overriding the Entra resource for WIF auth

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -118,6 +118,9 @@ const (
 	// Specify the identity provider to utilize for generating a workload identity
 	// federation attestation. Must be set when using OptionValueAuthWIF.
 	OptionIdentityProvider = "adbc.snowflake.sql.client_option.identity_provider"
+	// Specify the Entra resource to request a token for when OptionIdentityProvider
+	// is "AZURE". Optional; Snowflake's default resource is used if unset.
+	OptionIdentityProviderEntraResource = "adbc.snowflake.sql.client_option.identity_provider_entra_resource"
 
 	OptionClientId     = "adbc.snowflake.sql.client_option.client_id"
 	OptionClientSecret = "adbc.snowflake.sql.client_option.client_secret"

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -259,6 +259,8 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 		d.cfg.Host = v
 	case OptionIdentityProvider:
 		d.cfg.WorkloadIdentityProvider = v
+	case OptionIdentityProviderEntraResource:
+		d.cfg.WorkloadIdentityEntraResource = v
 	case OptionPort:
 		d.cfg.Port, err = strconv.Atoi(v)
 		if err != nil {

--- a/go/adbc/driver/snowflake/snowflake_database_test.go
+++ b/go/adbc/driver/snowflake/snowflake_database_test.go
@@ -35,3 +35,19 @@ func TestSetOptionInternal_NormalizesAccount(t *testing.T) {
 	require.NoError(t, err_b)
 	require.Equal(t, "my-account-name", db.cfg.Account)
 }
+
+func TestSetOptionInternal_WorkloadIdentity(t *testing.T) {
+	db := &databaseImpl{cfg: &gosnowflake.Config{}}
+
+	err := db.SetOptionInternal(OptionAuthType, OptionValueAuthWIF, nil)
+	require.NoError(t, err)
+	require.Equal(t, gosnowflake.AuthTypeWorkloadIdentityFederation, db.cfg.Authenticator)
+
+	err = db.SetOptionInternal(OptionIdentityProvider, "AZURE", nil)
+	require.NoError(t, err)
+	require.Equal(t, "AZURE", db.cfg.WorkloadIdentityProvider)
+
+	err = db.SetOptionInternal(OptionIdentityProviderEntraResource, "api://1111111-2222-3333-44444-55555555", nil)
+	require.NoError(t, err)
+	require.Equal(t, "api://1111111-2222-3333-44444-55555555", db.cfg.WorkloadIdentityEntraResource)
+}


### PR DESCRIPTION
## Summary
- `gosnowflake` (our fork, pinned at v1.17.7) already supports `WorkloadIdentityEntraResource` for Azure workload identity federation, alongside the existing `WorkloadIdentityProvider`. The ADBC driver only exposed an option for the latter.
- Adds `OptionIdentityProviderEntraResource` (`adbc.snowflake.sql.client_option.identity_provider_entra_resource`), wired to `cfg.WorkloadIdentityEntraResource`, mirroring the existing `OptionIdentityProvider` wiring exactly.
- Without this, Azure WIF still works against Snowflake's default Entra app (`api://fd3f753b-...`); this option is only needed for a custom Entra app registration.

## Context
Part of adding Snowflake WIF support to dbt Fusion (companion PR: dbt-labs/fs, branch `aswanson/snowflake-wif-fusion`). `OptionValueAuthWIF` / `OptionIdentityProvider` already existed and needed no changes.

## Test plan
- [x] `go build ./...` in `go/adbc/driver/snowflake`
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] New unit test `TestSetOptionInternal_WorkloadIdentity` covers `auth_wif`, `identity_provider`, and the new `identity_provider_entra_resource` option; passes alongside the existing `TestSetOptionInternal_NormalizesAccount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Tracking
dbt-labs/dbt-core#15927