### PR TITLE
databricks: classify exec errors instead of always returning StatusInternal

### DIFF
--- a/go/adbc/driver/databricks/statement.go
+++ b/go/adbc/driver/databricks/statement.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 
 	dbsqlctx "github.com/databricks/databricks-sql-go/driverctx"
+	dbsqlerr "github.com/databricks/databricks-sql-go/errors"
 	dbsqlrows "github.com/databricks/databricks-sql-go/rows"
 )
 
@@ -36,6 +38,24 @@ type statementImpl struct {
 	conn     *connectionImpl
 	query    string
 	prepared *sql.Stmt
+}
+
+func classifyError(action string, err error) adbc.Error {
+	code := adbc.StatusInternal
+	var execErr dbsqlerr.DBExecutionError
+	var reqErr dbsqlerr.DBRequestError
+	var drvErr dbsqlerr.DBDriverError
+	switch {
+	case errors.Is(err, context.Canceled):
+		code = adbc.StatusCancelled
+	case errors.Is(err, context.DeadlineExceeded):
+		code = adbc.StatusTimeout
+	case errors.As(err, &execErr):
+		code = adbc.StatusInvalidData
+	case errors.As(err, &reqErr) || errors.As(err, &drvErr):
+		code = adbc.StatusIO
+	}
+	return adbc.Error{Code: code, Msg: fmt.Sprintf("%s: %v", action, err)}
 }
 
 func (s *statementImpl) Close() error {
@@ -133,10 +153,7 @@ func (s *statementImpl) ExecuteQuery(ctx context.Context) (array.RecordReader, i
 	})
 
 	if err != nil {
-		return nil, -1, adbc.Error{
-			Code: adbc.StatusInternal,
-			Msg:  fmt.Sprintf("failed to execute query: %v", err),
-		}
+		return nil, -1, classifyError("failed to execute query", err)
 	}
 
 	// Convert to databricks rows interface to get Arrow batches
@@ -180,10 +197,7 @@ func (s *statementImpl) ExecuteUpdate(ctx context.Context) (int64, error) {
 	}
 
 	if err != nil {
-		return -1, adbc.Error{
-			Code: adbc.StatusInternal,
-			Msg:  fmt.Sprintf("failed to execute update: %v", err),
-		}
+		return -1, classifyError("failed to execute update", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()


### PR DESCRIPTION
## Problem
- `ExecuteQuery`/`ExecuteUpdate` mapped every error, regardless of cause, to `adbc.StatusInternal`
- No distinction between cancellation, timeout, query failure, or connection/auth issues

## Fix
- Add `classifyError`, checked in `statement.go`:
  - `context.Canceled` → `StatusCancelled`
  - `context.DeadlineExceeded` → `StatusTimeout`
  - `databricks-sql-go`'s `DBExecutionError` → `StatusInvalidData`
  - `DBRequestError`/`DBDriverError` → `StatusIO`
  - unrecognized → unchanged `StatusInternal` fallback

## Scope
- Only touches `statement.go`'s two execution paths (the ones relevant to dbt-labs/dbt-core#15366)
- `connection.go`'s catalog/schema/table-listing methods have the same blanket-`StatusInternal` pattern but are intentionally left untouched here

## Testing
- `go build`, `go vet`, `gofmt` clean
- Existing driver tests pass (one pre-existing, unrelated failure in `TestIPCReaderAdapter` confirmed present on `main` before this change)