### PR TITLE
databricks: bump databricks-sql-go to v1.14.2

### DIFF
--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/bluele/gcache v0.0.2
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/databricks/databricks-sdk-go v0.153.0
-	github.com/databricks/databricks-sql-go v1.14.0
+	github.com/databricks/databricks-sql-go v1.14.2
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
@@ -72,7 +72,7 @@ require (
 
 replace github.com/snowflakedb/gosnowflake => github.com/dbt-labs/gosnowflake v1.17.11
 
-replace github.com/databricks/databricks-sql-go => github.com/dbt-labs/databricks-sql-go v1.14.0
+replace github.com/databricks/databricks-sql-go => github.com/dbt-labs/databricks-sql-go v1.14.2
 
 require (
 	cloud.google.com/go v0.121.6

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dbt-labs/databricks-sql-go v1.14.0 h1:aMJQJsb+4u8D4c6YBGH/jJ0NN/GFrvZgdMbaLWsH8RM=
-github.com/dbt-labs/databricks-sql-go v1.14.0/go.mod h1:knb3jMMEf7rYm+Hw0i6NFuYC12WX7jkSQNhuz/D5V1Q=
+github.com/dbt-labs/databricks-sql-go v1.14.2 h1:Mk129zK7ana4QvGGO61dBrxg0sRbDVtOPMi3B997nAs=
+github.com/dbt-labs/databricks-sql-go v1.14.2/go.mod h1:knb3jMMEf7rYm+Hw0i6NFuYC12WX7jkSQNhuz/D5V1Q=
 github.com/dbt-labs/gosnowflake v1.17.11 h1:ozhz6/zjPS0mVXC54VIYMWNYYsNhUcjcP4fMs0rnjrM=
 github.com/dbt-labs/gosnowflake v1.17.11/go.mod h1:WPSInfc1Uemdhr6PQbPp0C7LW7j4u6pIe/+g2QuOwkQ=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=


### PR DESCRIPTION
## Problem
- `go.mod` pins `databricks-sql-go` at `v1.14.0`, which predates two fixes needed on this lineage:
  - the poll-abandonment fix for dbt-labs/dbt-core#15366 (ported as dbt-labs/databricks-sql-go#8, since the original fix, #7, landed on `main`, a branch not consumed anywhere)
  - `WithConnectTimeout` (ported as dbt-labs/databricks-sql-go#9 — this was already relied on by #154/#158 but the pin had drifted back to a version without it, which is why `main` currently fails to build)

## Fix
- Bump `require`/`replace` for `github.com/databricks/databricks-sql-go` from `v1.14.0` to `v1.14.2` (the tag at #9's merge commit, which includes both #8 and #9)
- `go mod tidy`

## Testing
- `go build ./...`, `go vet ./...` clean
- `go test ./driver/databricks/...`: `TestSetOptionConnectTimeout`, `TestResolveConnectionOptionsConnectTimeout`, `TestDefaultConnectTimeout` pass (confirms `WithConnectTimeout` now resolves and works against the bumped version)
- Two pre-existing, unrelated failures confirmed present before this change and untouched by this diff: `TestIPCReaderAdapter` (mock/interface mismatch) and `TestEffectiveQueryTags` (known bug in `effectiveQueryTags`, from PR#155's review)
