### PR TITLE
feat(go/adbc/driver/snowflake): support overriding the Entra resource for WIF auth

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -134,6 +134,9 @@ const (
 	// Specify the identity provider to utilize for generating a workload identity
 	// federation attestation. Must be set when using OptionValueAuthWIF.
 	OptionIdentityProvider = "adbc.snowflake.sql.client_option.identity_provider"
+	// Specify the Entra resource to request a token for when OptionIdentityProvider
+	// is "AZURE". Optional; Snowflake's default resource is used if unset.
+	OptionIdentityProviderEntraResource = "adbc.snowflake.sql.client_option.identity_provider_entra_resource"
 
 	OptionClientId     = "adbc.snowflake.sql.client_option.client_id"
 	OptionClientSecret = "adbc.snowflake.sql.client_option.client_secret"

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -267,6 +267,8 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 		d.cfg.Host = v
 	case OptionIdentityProvider:
 		d.cfg.WorkloadIdentityProvider = v
+	case OptionIdentityProviderEntraResource:
+		d.cfg.WorkloadIdentityEntraResource = v
 	case OptionPort:
 		d.cfg.Port, err = strconv.Atoi(v)
 		if err != nil {

--- a/go/adbc/driver/snowflake/snowflake_database_test.go
+++ b/go/adbc/driver/snowflake/snowflake_database_test.go
@@ -35,3 +35,19 @@ func TestSetOptionInternal_NormalizesAccount(t *testing.T) {
 	require.NoError(t, err_b)
 	require.Equal(t, "my-account-name", db.cfg.Account)
 }
+
+func TestSetOptionInternal_WorkloadIdentity(t *testing.T) {
+	db := &databaseImpl{cfg: &gosnowflake.Config{}}
+
+	err := db.SetOptionInternal(OptionAuthType, OptionValueAuthWIF, nil)
+	require.NoError(t, err)
+	require.Equal(t, gosnowflake.AuthTypeWorkloadIdentityFederation, db.cfg.Authenticator)
+
+	err = db.SetOptionInternal(OptionIdentityProvider, "AZURE", nil)
+	require.NoError(t, err)
+	require.Equal(t, "AZURE", db.cfg.WorkloadIdentityProvider)
+
+	err = db.SetOptionInternal(OptionIdentityProviderEntraResource, "api://1111111-2222-3333-44444-55555555", nil)
+	require.NoError(t, err)
+	require.Equal(t, "api://1111111-2222-3333-44444-55555555", db.cfg.WorkloadIdentityEntraResource)
+}


### PR DESCRIPTION
gosnowflake already supports WorkloadIdentityEntraResource for Azure workload identity federation, but no ADBC option exposed it. Adds identity_provider_entra_resource alongside the existing identity_provider option, mirroring its wiring.